### PR TITLE
Add doc(cfg) attributes

### DIFF
--- a/charming/Cargo.toml
+++ b/charming/Cargo.toml
@@ -34,3 +34,7 @@ features = [
 [features]
 ssr = ["deno_core", "image", "resvg", "serde_v8"]
 wasm = ["serde-wasm-bindgen", "wasm-bindgen", "web-sys"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/charming/src/lib.rs
+++ b/charming/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /*!
 Charming is a powerful and versatile chart rendering library for Rust that
 leverages the power of [Apache Echarts](https://echarts.apache.org/en/index.html)

--- a/charming/src/renderer/mod.rs
+++ b/charming/src/renderer/mod.rs
@@ -1,11 +1,15 @@
 pub mod html_renderer;
 #[cfg(feature = "ssr")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ssr")))]
 pub mod image_renderer;
 #[cfg(feature = "wasm")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wasm")))]
 pub mod wasm_renderer;
 
 pub use html_renderer::*;
 #[cfg(feature = "ssr")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ssr")))]
 pub use image_renderer::*;
 #[cfg(feature = "wasm")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wasm")))]
 pub use wasm_renderer::*;


### PR DESCRIPTION
This configures docs.rs to generates docs for all features and adds feature annotations. Hopefully this will help with some of the confusion of how to use the different renderers

This is done using [doc(cfg)](https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html). Though this is a nightly feature, it is only used by docsrs which already runs on nightly. Crates like [tokio](https://docs.rs/tokio/latest/tokio/) already use this feature, so it should be ok to use despite it being nightly.

If you want to generate the docs locally, you can run:
```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
```
Docs can still be generated normally without nightly, but they just won't have the annotations