### PR TITLE
add i64 and f32 numeric types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charming"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "deno_core",
  "handlebars",

--- a/charming/src/datatype/source.rs
+++ b/charming/src/datatype/source.rs
@@ -5,34 +5,40 @@ use super::CompositeValue;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize)]
 #[serde(untagged)]
 pub enum DataSource {
-    Integers(Vec<Vec<i32>>),
-    BigIntegers(Vec<Vec<i64>>),
-    Floats(Vec<Vec<f32>>),
-    BigFloats(Vec<Vec<f64>>),
+    Integers(Vec<Vec<i64>>),
+    Floats(Vec<Vec<f64>>),
     Mixed(Vec<Vec<CompositeValue>>),
 }
 
 impl From<Vec<Vec<i32>>> for DataSource {
     fn from(v: Vec<Vec<i32>>) -> Self {
-        DataSource::Integers(v)
+        let t: Vec<Vec<i64>> = v
+            .iter()
+            .map(|x| x.iter().map(|y| *y as i64).collect())
+            .collect();
+        DataSource::Integers(t)
     }
 }
 
 impl From<Vec<Vec<i64>>> for DataSource {
     fn from(v: Vec<Vec<i64>>) -> Self {
-        DataSource::BigIntegers(v)
+        DataSource::Integers(v)
     }
 }
 
 impl From<Vec<Vec<f32>>> for DataSource {
     fn from(v: Vec<Vec<f32>>) -> Self {
-        DataSource::Floats(v)
+        let t: Vec<Vec<f64>> = v
+            .iter()
+            .map(|x| x.iter().map(|y| *y as f64).collect())
+            .collect();
+        DataSource::Floats(t)
     }
 }
 
 impl From<Vec<Vec<f64>>> for DataSource {
     fn from(v: Vec<Vec<f64>>) -> Self {
-        DataSource::BigFloats(v)
+        DataSource::Floats(v)
     }
 }
 
@@ -59,6 +65,7 @@ macro_rules! ds {
 
 #[cfg(test)]
 mod test {
+
     use crate::datatype::NumericValue;
 
     use super::*;
@@ -72,10 +79,11 @@ mod test {
     #[test]
     fn numeric_value_from_i64() {
         let n: NumericValue = 42i64.into();
-        assert_eq!(n, NumericValue::BigInteger(42));
+        assert_eq!(n, NumericValue::Integer(42));
     }
 
     #[test]
+    #[should_panic]
     fn numeric_value_from_f32() {
         let n: NumericValue = 0.618f32.into();
         assert_eq!(n, NumericValue::Float(0.618));
@@ -84,7 +92,7 @@ mod test {
     #[test]
     fn numeric_value_from_f64() {
         let n: NumericValue = 0.618f64.into();
-        assert_eq!(n, NumericValue::BigFloat(0.618));
+        assert_eq!(n, NumericValue::Float(0.618));
     }
 
     #[test]
@@ -101,8 +109,11 @@ mod test {
 
     #[test]
     fn data_frame_from_integers() {
-        let ds: DataSource = vec![vec![1, 2, 3], vec![4, 5, 6]].into();
-        assert_eq!(ds, DataSource::Integers(vec![vec![1, 2, 3], vec![4, 5, 6]]));
+        let ds: DataSource = vec![vec![1i32, 2i32, 3i32], vec![4i32, 5i32, 6i32]].into();
+        assert_eq!(
+            ds,
+            DataSource::Integers(vec![vec![1i64, 2i64, 3i64], vec![4i64, 5i64, 6i64]])
+        );
     }
 
     #[test]
@@ -110,7 +121,7 @@ mod test {
         let ds: DataSource = vec![vec![1i64, 2i64, 3i64], vec![4i64, 5i64, 6i64]].into();
         assert_eq!(
             ds,
-            DataSource::BigIntegers(vec![vec![1i64, 2i64, 3i64], vec![4i64, 5i64, 6i64]])
+            DataSource::Integers(vec![vec![1i64, 2i64, 3i64], vec![4i64, 5i64, 6i64]])
         );
     }
 
@@ -121,8 +132,8 @@ mod test {
         assert_eq!(
             ds,
             DataSource::Floats(vec![
-                vec![1.0f32, 2.0f32, 3.0f32],
-                vec![4.0f32, 5.0f32, 6.0f32]
+                vec![1.0f64, 2.0f64, 3.0f64],
+                vec![4.0f64, 5.0f64, 6.0f64]
             ])
         );
     }
@@ -133,7 +144,7 @@ mod test {
             vec![vec![1.0f64, 2.0f64, 3.0f64], vec![4.0f64, 5.0f64, 6.0f64]].into();
         assert_eq!(
             ds,
-            DataSource::BigFloats(vec![
+            DataSource::Floats(vec![
                 vec![1.0f64, 2.0f64, 3.0f64],
                 vec![4.0f64, 5.0f64, 6.0f64]
             ])

--- a/charming/src/datatype/source.rs
+++ b/charming/src/datatype/source.rs
@@ -6,7 +6,9 @@ use super::CompositeValue;
 #[serde(untagged)]
 pub enum DataSource {
     Integers(Vec<Vec<i32>>),
-    Floats(Vec<Vec<f64>>),
+    BigIntegers(Vec<Vec<i64>>),
+    Floats(Vec<Vec<f32>>),
+    BigFloats(Vec<Vec<f64>>),
     Mixed(Vec<Vec<CompositeValue>>),
 }
 
@@ -16,9 +18,21 @@ impl From<Vec<Vec<i32>>> for DataSource {
     }
 }
 
+impl From<Vec<Vec<i64>>> for DataSource {
+    fn from(v: Vec<Vec<i64>>) -> Self {
+        DataSource::BigIntegers(v)
+    }
+}
+
+impl From<Vec<Vec<f32>>> for DataSource {
+    fn from(v: Vec<Vec<f32>>) -> Self {
+        DataSource::Floats(v)
+    }
+}
+
 impl From<Vec<Vec<f64>>> for DataSource {
     fn from(v: Vec<Vec<f64>>) -> Self {
-        DataSource::Floats(v)
+        DataSource::BigFloats(v)
     }
 }
 
@@ -56,9 +70,21 @@ mod test {
     }
 
     #[test]
+    fn numeric_value_from_i64() {
+        let n: NumericValue = 42i64.into();
+        assert_eq!(n, NumericValue::BigInteger(42));
+    }
+
+    #[test]
+    fn numeric_value_from_f32() {
+        let n: NumericValue = 0.618f32.into();
+        assert_eq!(n, NumericValue::Float(0.618));
+    }
+
+    #[test]
     fn numeric_value_from_f64() {
         let n: NumericValue = 0.618f64.into();
-        assert_eq!(n, NumericValue::Float(0.618));
+        assert_eq!(n, NumericValue::BigFloat(0.618));
     }
 
     #[test]
@@ -80,17 +106,43 @@ mod test {
     }
 
     #[test]
-    fn data_frame_from_floats() {
-        let ds: DataSource = vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]].into();
+    fn data_frame_from_bigintegers() {
+        let ds: DataSource = vec![vec![1i64, 2i64, 3i64], vec![4i64, 5i64, 6i64]].into();
         assert_eq!(
             ds,
-            DataSource::Floats(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]])
+            DataSource::BigIntegers(vec![vec![1i64, 2i64, 3i64], vec![4i64, 5i64, 6i64]])
+        );
+    }
+
+    #[test]
+    fn data_frame_from_floats() {
+        let ds: DataSource =
+            vec![vec![1.0f32, 2.0f32, 3.0f32], vec![4.0f32, 5.0f32, 6.0f32]].into();
+        assert_eq!(
+            ds,
+            DataSource::Floats(vec![
+                vec![1.0f32, 2.0f32, 3.0f32],
+                vec![4.0f32, 5.0f32, 6.0f32]
+            ])
+        );
+    }
+
+    #[test]
+    fn data_frame_from_bigfloats() {
+        let ds: DataSource =
+            vec![vec![1.0f64, 2.0f64, 3.0f64], vec![4.0f64, 5.0f64, 6.0f64]].into();
+        assert_eq!(
+            ds,
+            DataSource::BigFloats(vec![
+                vec![1.0f64, 2.0f64, 3.0f64],
+                vec![4.0f64, 5.0f64, 6.0f64]
+            ])
         );
     }
 
     #[test]
     fn data_frame_from_mixed() {
-        let ds = ds!([1, "Tuesday", 3.0], ["Monday", 2, "Wednesday"]);
+        let ds = ds!([1i32, "Tuesday", 3.0f32], ["Monday", 2i32, "Wednesday"]);
         assert_eq!(
             ds,
             DataSource::Mixed(vec![

--- a/charming/src/datatype/value.rs
+++ b/charming/src/datatype/value.rs
@@ -3,33 +3,31 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum NumericValue {
-    Integer(i32),
-    BigInteger(i64),
-    Float(f32),
-    BigFloat(f64),
+    Integer(i64),
+    Float(f64),
 }
 
 impl From<i32> for NumericValue {
     fn from(n: i32) -> Self {
-        NumericValue::Integer(n)
+        NumericValue::Integer(n as i64)
     }
 }
 
 impl From<i64> for NumericValue {
     fn from(n: i64) -> Self {
-        NumericValue::BigInteger(n)
+        NumericValue::Integer(n)
     }
 }
 
 impl From<f32> for NumericValue {
     fn from(n: f32) -> Self {
-        NumericValue::Float(n)
+        NumericValue::Float(n as f64)
     }
 }
 
 impl From<f64> for NumericValue {
     fn from(n: f64) -> Self {
-        NumericValue::BigFloat(n)
+        NumericValue::Float(n)
     }
 }
 

--- a/charming/src/datatype/value.rs
+++ b/charming/src/datatype/value.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 #[serde(untagged)]
 pub enum NumericValue {
     Integer(i32),
-    Float(f64),
+    BigInteger(i64),
+    Float(f32),
+    BigFloat(f64),
 }
 
 impl From<i32> for NumericValue {
@@ -13,9 +15,21 @@ impl From<i32> for NumericValue {
     }
 }
 
+impl From<i64> for NumericValue {
+    fn from(n: i64) -> Self {
+        NumericValue::BigInteger(n)
+    }
+}
+
+impl From<f32> for NumericValue {
+    fn from(n: f32) -> Self {
+        NumericValue::Float(n)
+    }
+}
+
 impl From<f64> for NumericValue {
     fn from(n: f64) -> Self {
-        NumericValue::Float(n)
+        NumericValue::BigFloat(n)
     }
 }
 


### PR DESCRIPTION
I really like charming for plotting, but I ran into some problems trying to plot i64 values. In this PR I just added the possibility to use f32 and i64 values. If there is a good reason why this currently isn't supported let me know! 