### PR TITLE
Resizing echarts with wasm renderer

### DIFF
--- a/charming/src/renderer/wasm_renderer.rs
+++ b/charming/src/renderer/wasm_renderer.rs
@@ -24,7 +24,7 @@ impl WasmRenderer {
         self
     }
 
-    pub fn render(&self, id: &str, chart: &Chart) -> Result<(), EchartsError> {
+    pub fn render(&self, id: &str, chart: &Chart) -> Result<Echarts, EchartsError> {
         let window = web_sys::window().ok_or(EchartsError::WasmError(
             "no `window` object found".to_string(),
         ))?;
@@ -47,7 +47,14 @@ impl WasmRenderer {
             .unwrap(),
         );
         echarts.set_option(to_value(chart).unwrap());
-        Ok(())
+
+        Ok(echarts)
+    }
+
+    /// Resizes a chart with options specified in [`ChartResize`]
+    pub fn resize_chart(echarts: &Echarts, chart_size: ChartResize) {
+        echarts
+            .resize(to_value(&chart_size).expect("could not convert resize options to `JsValue`"));
     }
 }
 
@@ -57,14 +64,94 @@ struct ChartSize {
     height: u32,
 }
 
+#[derive(Serialize)]
+pub struct ChartResize {
+    /// New width in px
+    width: u32,
+    /// New height in px
+    height: u32,
+    /// If true, emits events on resize
+    silent: bool,
+    /// Resize animation options
+    animation: Option<Animation>,
+}
+
+#[derive(Serialize)]
+pub struct Animation {
+    /// duration of the animation
+    pub duration: u32,
+    /// easing function used for the animation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub easing: Option<Easing>,
+}
+
+/// available easing functions in echarts
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Easing {
+    #[default]
+    Linear,
+    QuadraticIn,
+    QuadraticOut,
+    QuadraticInOut,
+    CubicIn,
+    CubicOut,
+    CubicInOut,
+    QuarticIn,
+    QuarticOut,
+    QuarticInOut,
+    QuinticIn,
+    QuinticOut,
+    QuinticInOut,
+    SinusoidalIn,
+    SinusoidalOut,
+    SinusoidalInOut,
+    ExponentialIn,
+    ExponentialOut,
+    ExponentialInOut,
+    CircularIn,
+    CircularOut,
+    CircularInOut,
+    ElasticIn,
+    ElasticOut,
+    ElasticInOut,
+    BackIn,
+    BackOut,
+    BackInOut,
+    BounceIn,
+    BounceOut,
+    BounceInOut,
+}
+
+impl Default for Animation {
+    fn default() -> Self {
+        Self {
+            duration: 100,
+            easing: Some(Easing::default()),
+        }
+    }
+}
+
+impl Animation {
+    pub fn new(duration: u32, easing: Option<Easing>) -> Self {
+        Self {
+            duration,
+            easing: easing.or_else(|| Some(Easing::default())),
+        }
+    }
+}
+
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_name = echarts)]
-    type Echarts;
+    pub type Echarts;
 
     #[wasm_bindgen(js_namespace = echarts, js_name = init)]
     fn init(id: &web_sys::Element, theme: &str, size: JsValue) -> Echarts;
 
     #[wasm_bindgen(method, js_name = "setOption")]
     fn set_option(this: &Echarts, option: JsValue);
+
+    #[wasm_bindgen(method, js_name = "resize")]
+    pub fn resize(this: &Echarts, opts: JsValue);
 }


### PR DESCRIPTION
I was not able to resize charts properly after rendering with the wasm renderer. This PR just generates binding to the resize function from echarts and adds types and enums for the resizing options. I had to return the `Echarts` type from the `init` function to give access to the initialized chart instance, which makes the api also for future bindings more flexible.