### PR TITLE
Adding layoutIterations() support

### DIFF
--- a/charming/src/series/sankey.rs
+++ b/charming/src/series/sankey.rs
@@ -100,6 +100,9 @@ pub struct Sankey {
     emphasis: Option<Emphasis>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    layout_iterations: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     orient: Option<Orient>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -133,6 +136,7 @@ impl Sankey {
             width: None,
             height: None,
             emphasis: None,
+            layout_iterations: None,
             orient: None,
             label: None,
             node_align: None,
@@ -194,6 +198,11 @@ impl Sankey {
 
     pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
         self.emphasis = Some(emphasis.into());
+        self
+    }
+
+    pub fn layout_iterations<F: Into<u64>>(mut self, layout_iterations: F) -> Self {
+        self.layout_iterations = Some(layout_iterations.into());
         self
     }
 


### PR DESCRIPTION
I'm using the change in this PR already - so it probably can be merged I guess. 

If you want to play with it:

https://echarts.apache.org/examples/en/editor.html?c=sankey-simple&lang=ts&version=5.4.4-dev.20231111&decal=1

```
option = {
  series: {
    type: 'sankey',
    layout: 'none',
    layoutIterations: 0,
    emphasis: {
        focus: 'adjacency'
    },
    data: [
{ name: 'b1' },
{ name: 'b' },
{ name: 'a' },
{ name: 'c' },
{ name: 'a1' },
{ name: 'a3' },
{ name: 'aa' },


    ],
    links: [
      {source: 'b',target: 'b1',value: 1},
      {source: 'a',target: 'a1',value: 5},
      {source: 'a',target: 'b1',value: 2},

      {source: 'b1',target: 'c',value: 2},
      {source: 'b1',target: 'a1',value: 1},
      {source: 'a',target: 'aa',value: 3},
      {source: 'aa',target: 'a3',value: 3},
    ]
  }
};
```