### PR TITLE
Klick builder pattern

### DIFF
--- a/charming/src/element/border_type.rs
+++ b/charming/src/element/border_type.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum BorderType {
     Solid,

--- a/charming/src/element/border_type.rs
+++ b/charming/src/element/border_type.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum BorderType {
     Solid,

--- a/charming/src/element/color.rs
+++ b/charming/src/element/color.rs
@@ -18,7 +18,7 @@ impl From<&str> for ColorBy {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 pub struct ColorStop {
     offset: f64,
     color: String,
@@ -33,6 +33,7 @@ impl ColorStop {
     }
 }
 
+#[derive(Clone, Debug)]
 pub enum Color {
     Value(String),
     LinearGradient {

--- a/charming/src/element/color.rs
+++ b/charming/src/element/color.rs
@@ -1,5 +1,5 @@
 use serde::ser::{SerializeStruct, Serializer};
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -18,7 +18,7 @@ impl From<&str> for ColorBy {
     }
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ColorStop {
     offset: f64,
     color: String,
@@ -33,7 +33,7 @@ impl ColorStop {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub enum Color {
     Value(String),
     LinearGradient {

--- a/charming/src/element/item_style.rs
+++ b/charming/src/element/item_style.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::{border_type::BorderType, color::Color};
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ItemStyle {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/item_style.rs
+++ b/charming/src/element/item_style.rs
@@ -1,8 +1,7 @@
-use serde::Serialize;
-
+use serde::{Serialize, Deserialize};
 use super::{border_type::BorderType, color::Color};
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ItemStyle {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/series/sankey.rs
+++ b/charming/src/series/sankey.rs
@@ -13,7 +13,7 @@ pub enum SankeyNodeAlign {
     Justify,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SankeyNode {
     pub name: String,

--- a/charming/src/series/sankey.rs
+++ b/charming/src/series/sankey.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
-    element::{Emphasis, Label, LineStyle, Orient},
+    element::{Emphasis, Label, LineStyle, Orient, ItemStyle},
 };
 
 #[derive(Serialize)]
@@ -13,7 +13,7 @@ pub enum SankeyNodeAlign {
     Justify,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SankeyNode {
     pub name: String,
@@ -23,17 +23,46 @@ pub struct SankeyNode {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub depth: Option<f64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_style: Option<ItemStyle>,
+}
+
+impl SankeyNode {
+    pub fn new<S>(name: S) -> Self where S: Into<String> {
+        Self {
+            name: name.into(),
+            value: None,
+            depth: None,
+            item_style: None,
+        }
+    }
+
+    pub fn value<V: Into<f64>>(mut self, value: V) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+    pub fn depth<D: Into<f64>>(mut self, depth: D) -> Self {
+        self.depth = Some(depth.into());
+        self
+    }
+
+    pub fn item_style<S: Into<ItemStyle>>(mut self, item_style: S) -> Self {
+        self.item_style = Some(item_style.into());
+        self
+    }
 }
 
 impl<S> From<S> for SankeyNode
-where
-    S: Into<String>,
+    where
+        S: Into<String>,
 {
     fn from(name: S) -> Self {
         SankeyNode {
             name: name.into(),
             value: None,
             depth: None,
+            item_style: None,
         }
     }
 }


### PR DESCRIPTION
Adding **item_style** support in **SankeyNode** using builder pattern:

    let mut labels: Vec<SankeyNode> = vec![];

    let label = "foo";
    let my_style = ItemStyle::new().color("red").border_color("black");
    let sn = SankeyNode::new(label).item_style(my_style);

    labels.push(sn);

This way one can override the echarts sankey colors for nodes and organize the coloring!

    let chart = Chart::new().series(
        Sankey::new()
            .layout_iterations(0u64)
            .links(sankey_links)
            .data(labels)
    );

Note, this includes https://github.com/yuankunzhang/charming/pull/29


This is similar to:

```
let one = "green";
let two = "#DE3163";
let three = "orange";

option = 
{
  "series": [
    {
      "type": "sankey",

      "layoutIterations": 0,
      lineStyle: {
        color: 'source',
        curveness: 0.4
      },
      "links": [ 
        {
          "source": "Nutzung 2.179",
          "target": "Emission 2.179",
          "value": 2178.4796516480023
        }
      ],
      "data": [
        {
          "name": "Nutzung 2.179",
          itemStyle: {
            color: two,
            borderColor: 'black'
          },
                  },
        {
          "name": "Emission 2.179",
          itemStyle: {
            color: two,
            borderColor: 'black'
          }
        }
      ]
    }
  ]
};
```

https://echarts.apache.org/examples/en/editor.html?c=sankey-simple&lang=ts&version=5.4.4-dev.20231111&decal=1