### PR TITLE
implements std Error and Display traits for EchartsError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charming"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "deno_core",
  "handlebars",

--- a/charming/src/lib.rs
+++ b/charming/src/lib.rs
@@ -524,3 +524,10 @@ pub enum EchartsError {
     JsRuntimeError(String),
     WasmError(String),
 }
+
+impl std::error::Error for EchartsError {}
+impl std::fmt::Display for EchartsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}


### PR DESCRIPTION
When using charming, I discovered that EChartsError doesn't implement Display or std::error::Error.

Implementing these traits would allow the use of `-> Result<_, Box<dyn std::error::Error>>` in client code.

I'm not sure if this is right for this codebase, but I thought I would propose it. Thanks for considering it!
