### PR TITLE
replacing ImageFormat::PNG to ImageFormat::Png in tutorial code

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ let mut renderer = ImageRenderer::new(1000, 800);
 // Render the chart as SVG string.
 renderer.render(&chart).unwrap();
 // Render the chart as PNG bytes.
-renderer.render_format(ImageFormat::PNG, &chart).unwrap();
+renderer.render_format(ImageFormat::Png, &chart).unwrap();
 // Save the chart as SVG file.
 renderer.save(&chart, "/tmp/chart.svg").unwrap();
 // Save the chart as PNG file.
-renderer.save_format(ImageFormat::PNG, &chart, "/tmp/chart.png");
+renderer.save_format(ImageFormat::Png, &chart, "/tmp/chart.png");
 
 
 // Use WasmRenderer. The `wasm` feature needs to be enabled.


### PR DESCRIPTION
## Issue
The tutorial code in the [README.md of charming](https://github.com/yuankunzhang/charming#renderers) contains an incorrect usage of the ImageFormat enum from the image crate. The enum variant ImageFormat::PNG should be ImageFormat::Png.

## Solution
The solution involves updating the README.md file to reflect the correct enum variant. The incorrect instances of ImageFormat::PNG have been replaced with ImageFormat::Png.

## Changes Made
Replaced ImageFormat::PNG with ImageFormat::Png in the tutorial code for ImageRenderer.
### Updated Code

```rust
// Use HtmlRenderer.
use charming::HtmlRenderer;

// Chart dimension 1000x800.
let renderer = HtmlRenderer::new("my charts", 1000, 800);
// Render the chart as HTML string.
let html_str = renderer.render(&chart).unwrap();
// Save the chart as HTML file.
renderer.save(&chart, "/tmp/chart.html").unwrap();


// Use ImageRenderer. The `ssr` feature needs to be enabled.
use charming::{ImageRenderer, ImageFormat};

// Chart dimension 1000x800.
let mut renderer = ImageRenderer::new(1000, 800);
// Render the chart as SVG string.
renderer.render(&chart).unwrap();
// Render the chart as PNG bytes.
renderer.render_format(ImageFormat::Png, &chart).unwrap();
// Save the chart as SVG file.
renderer.save(&chart, "/tmp/chart.svg").unwrap();
// Save the chart as PNG file.
renderer.save_format(ImageFormat::Png, &chart, "/tmp/chart.png").unwrap();


// Use WasmRenderer. The `wasm` feature needs to be enabled.
use charming::WasmRenderer;

// Chart dimension 1000x800.
let renderer = WasmRenderer::new(1000, 800);
// Render the chart in the WebAssembly runtime
renderer.render(&chart).unwrap();
```

## Documentation
The README.md file has been updated to ensure correct usage of ImageFormat enum variants, providing accurate guidance for users following the tutorial.


## Reference
I checked `image::ImageFormat` by [docs rs](https://docs.rs/image/latest/image/enum.ImageFormat.html) and found implementation for it.

```rust
/// An enumeration of supported image formats.
/// Not all formats support both encoding and decoding.
#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
#[non_exhaustive]
pub enum ImageFormat {
    /// An Image in PNG Format
    Png,

    /// An Image in JPEG Format
    Jpeg,

    /// An Image in GIF Format
    Gif,

    /// An Image in WEBP Format
    WebP,

    // and so on ...
}
```