### PR TITLE
Make resizing possible while using WasmRenderer

### DIFF
--- a/charming/src/renderer/wasm_renderer.rs
+++ b/charming/src/renderer/wasm_renderer.rs
@@ -71,13 +71,13 @@ struct ChartSize {
 #[derive(Serialize)]
 pub struct ChartResize {
     /// New width in px
-    width: u32,
+    pub width: u32,
     /// New height in px
-    height: u32,
+    pub height: u32,
     /// If true, emits events on resize
-    silent: bool,
+    pub silent: bool,
     /// Resize animation options
-    animation: Option<Animation>,
+    pub animation: Option<Animation>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Because the ChartResize fields are not public, resizing is impossible to achieve using the charming API. 

In my project, I had to use a workaround, which basically involved copypasting some code from the library and making the ChartResize fields public to call the JS resize method.

Relates to issue #34 