### PR TITLE
Allowing not specify size to WasmRenderer

### DIFF
--- a/charming/src/renderer/wasm_renderer.rs
+++ b/charming/src/renderer/wasm_renderer.rs
@@ -6,12 +6,20 @@ use wasm_bindgen::JsValue;
 
 pub struct WasmRenderer {
     theme: Theme,
-    width: u32,
-    height: u32,
+    width: Option<u32>,
+    height: Option<u32>,
 }
 
 impl WasmRenderer {
     pub fn new(width: u32, height: u32) -> Self {
+        Self {
+            theme: Theme::Default,
+            width: Some(width),
+            height: Some(height),
+        }
+    }
+
+    pub fn new_opt(width: Option<u32>, height: Option<u32>) -> Self {
         Self {
             theme: Theme::Default,
             width,
@@ -64,8 +72,8 @@ impl WasmRenderer {
 
 #[derive(Serialize)]
 struct ChartSize {
-    width: u32,
-    height: u32,
+    width: Option<u32>,
+    height: Option<u32>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Now you need to specify the exact size of the chart. 
This does not allow you to fill all the available space and the **resize()** method without parameters also does not change the size when the parent is resized. 

If you do not set the width, for example, then the chart adjusts to the width of the parent and when it is resized, you can  call **resize()** and chart fits parent.

Added new function new_opt for constructing WasmRenderer with optional arguments. 
Function **new()** also working. 

```rust
 let renderer = WasmRenderer::new_opt(None, Some(300));
 renderer.render("chart", &chart).unwrap();
```
initial chart width set automatic to full width:

<img width="1057" alt="image" src="https://github.com/yuankunzhang/charming/assets/1934951/19036fc4-fdb1-4555-afe0-42c102463c27">

<img width="551" alt="image" src="https://github.com/yuankunzhang/charming/assets/1934951/177b3d51-6a09-48e6-9a04-09dfc15e5a96">
