### PR TITLE
feat: allow using Formatter::Function from WASM

### DIFF
--- a/charming/src/element/formatter.rs
+++ b/charming/src/element/formatter.rs
@@ -1,11 +1,15 @@
-use serde::Serialize;
-
 use super::RawString;
+use serde::Serialize;
 
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum Formatter {
     String(String),
+
+    #[cfg(target_arch = "wasm32")]
+    Function(#[serde(with = "serde_wasm_bindgen::preserve")] web_sys::js_sys::Function),
+
+    #[cfg(not(target_arch = "wasm32"))]
     Function(RawString),
 }
 
@@ -15,6 +19,7 @@ impl From<&str> for Formatter {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<RawString> for Formatter {
     fn from(s: RawString) -> Self {
         Formatter::Function(s)

--- a/charming/src/element/formatter.rs
+++ b/charming/src/element/formatter.rs
@@ -2,15 +2,62 @@ use super::RawString;
 use serde::Serialize;
 
 #[derive(Serialize)]
+#[serde(transparent)]
+pub struct FormatterFunction {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub value: RawString,
+    #[cfg(target_arch = "wasm32")]
+    pub value: web_sys::js_sys::Function,
+}
+
+impl FormatterFunction {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn new_no_args(body: &str) -> FormatterFunction {
+        FormatterFunction {
+            value: RawString::from(format!("function() {{ {} }}", body)),
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn new_no_args(body: &str) -> FormatterFunction {
+        FormatterFunction {
+            value: web_sys::js_sys::Function::new_no_args(body),
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn new_with_args(args: &str, body: &str) -> FormatterFunction {
+        FormatterFunction {
+            value: RawString::from(format!("function({}) {{ {} }}", args, body)),
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn new_with_args(args: &str, body: &str) -> FormatterFunction {
+        FormatterFunction {
+            value: web_sys::js_sys::Function::new_with_args(args, body),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+
+impl<S> From<S> for FormatterFunction
+where
+    S: Into<String>,
+{
+    fn from(s: S) -> Self {
+        FormatterFunction {
+            value: RawString::from(s),
+        }
+    }
+}
+
+#[derive(Serialize)]
 #[serde(untagged)]
 pub enum Formatter {
     String(String),
-
-    #[cfg(target_arch = "wasm32")]
-    Function(#[serde(with = "serde_wasm_bindgen::preserve")] web_sys::js_sys::Function),
-
-    #[cfg(not(target_arch = "wasm32"))]
-    Function(RawString),
+    Function(FormatterFunction),
 }
 
 impl From<&str> for Formatter {
@@ -22,6 +69,12 @@ impl From<&str> for Formatter {
 #[cfg(not(target_arch = "wasm32"))]
 impl From<RawString> for Formatter {
     fn from(s: RawString) -> Self {
-        Formatter::Function(s)
+        Formatter::Function(FormatterFunction { value: s })
+    }
+}
+
+impl From<FormatterFunction> for Formatter {
+    fn from(f: FormatterFunction) -> Self {
+        Formatter::Function(f)
     }
 }

--- a/charming/src/element/symbol_size.rs
+++ b/charming/src/element/symbol_size.rs
@@ -1,12 +1,12 @@
 use serde::Serialize;
 
-use super::RawString;
+use super::{FormatterFunction, RawString};
 
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum SymbolSize {
     Number(f64),
-    Function(RawString),
+    Function(FormatterFunction),
 }
 
 impl From<i64> for SymbolSize {
@@ -21,8 +21,17 @@ impl From<f64> for SymbolSize {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<&str> for SymbolSize {
     fn from(s: &str) -> Self {
-        SymbolSize::Function(RawString::from(s))
+        SymbolSize::Function(FormatterFunction {
+            value: RawString::from(s),
+        })
+    }
+}
+
+impl From<FormatterFunction> for SymbolSize {
+    fn from(f: FormatterFunction) -> Self {
+        SymbolSize::Function(f)
     }
 }

--- a/charming/src/element/tooltip.rs
+++ b/charming/src/element/tooltip.rs
@@ -37,6 +37,9 @@ pub struct Tooltip {
     formatter: Option<Formatter>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    value_formatter: Option<Formatter>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     position: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -65,6 +68,7 @@ impl Tooltip {
             trigger_on: None,
             axis_pointer: None,
             formatter: None,
+            value_formatter: None,
             position: None,
             padding: None,
             background_color: None,
@@ -90,6 +94,11 @@ impl Tooltip {
 
     pub fn formatter<F: Into<Formatter>>(mut self, formatter: F) -> Self {
         self.formatter = Some(formatter.into());
+        self
+    }
+
+    pub fn value_formatter<F: Into<Formatter>>(mut self, value_formatter: F) -> Self {
+        self.value_formatter = Some(value_formatter.into());
         self
     }
 


### PR DESCRIPTION
We can create functions directly using `js_sys::Function::new_with_args` for example when using WASM. Fixes #66 