### PR TITLE
Add value formatter to tooltip

### DIFF
--- a/charming/src/element/tooltip.rs
+++ b/charming/src/element/tooltip.rs
@@ -37,6 +37,9 @@ pub struct Tooltip {
     formatter: Option<Formatter>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    value_formatter: Option<Formatter>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     position: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -65,6 +68,7 @@ impl Tooltip {
             trigger_on: None,
             axis_pointer: None,
             formatter: None,
+            value_formatter: None,
             position: None,
             padding: None,
             background_color: None,
@@ -90,6 +94,11 @@ impl Tooltip {
 
     pub fn formatter<F: Into<Formatter>>(mut self, formatter: F) -> Self {
         self.formatter = Some(formatter.into());
+        self
+    }
+
+    pub fn value_formatter<F: Into<Formatter>>(mut self, value_formatter: F) -> Self {
+        self.value_formatter = Some(value_formatter.into());
         self
     }
 

--- a/gallery/src/line/distribution_of_electricity.rs
+++ b/gallery/src/line/distribution_of_electricity.rs
@@ -1,8 +1,8 @@
 use charming::{
     component::{Axis, Feature, SaveAsImage, Title, Toolbox, VisualMap, VisualMapPiece},
     element::{
-        AxisLabel, AxisPointer, AxisPointerType, AxisType, ItemStyle, MarkArea, MarkAreaData,
-        Tooltip, Trigger,
+        AxisLabel, AxisPointer, AxisPointerType, AxisType, Formatter, ItemStyle, MarkArea,
+        MarkAreaData, Tooltip, Trigger,
     },
     series::Line,
     Chart,
@@ -18,7 +18,8 @@ pub fn chart() -> Chart {
         .tooltip(
             Tooltip::new()
                 .trigger(Trigger::Axis)
-                .axis_pointer(AxisPointer::new().type_(AxisPointerType::Cross)),
+                .axis_pointer(AxisPointer::new().type_(AxisPointerType::Cross))
+                .value_formatter(Formatter::Function("value => value + 'W'".into())),
         )
         .toolbox(
             Toolbox::new()


### PR DESCRIPTION
Allows use of value_formatter in tooltips, a feature added to echarts in v5.3.0 ( [link](https://echarts.apache.org/handbook/en/basics/release-note/5-3-0/) )

I also amended an example to show it in action: ![image](https://github.com/user-attachments/assets/5c853759-80ef-465c-9f56-acb81ae452c8)
