### PR TITLE
add selected to legend

### DIFF
--- a/charming/src/component/legend.rs
+++ b/charming/src/component/legend.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::Serialize;
 
 use crate::{
@@ -159,6 +161,9 @@ pub struct Legend {
     formatter: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    selected: Option<HashMap<String, bool>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     selected_mode: Option<LegendSelectedMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -202,6 +207,7 @@ impl Legend {
             text_style: None,
             symbol_rotate: None,
             formatter: None,
+            selected: None,
             selected_mode: None,
             border_color: None,
             inactive_color: None,
@@ -311,6 +317,14 @@ impl Legend {
 
     pub fn formatter<S: Into<String>>(mut self, formatter: S) -> Self {
         self.formatter = Some(formatter.into());
+        self
+    }
+
+    pub fn selected<S: Into<String>, I: IntoIterator<Item = (S, bool)>>(
+        mut self,
+        selected: I,
+    ) -> Self {
+        self.selected = Some(selected.into_iter().map(|(k, v)| (k.into(), v)).collect());
         self
     }
 

--- a/gallery/src/line/stacked_line.rs
+++ b/gallery/src/line/stacked_line.rs
@@ -9,13 +9,18 @@ pub fn chart() -> Chart {
     Chart::new()
         .title(Title::new().text("Stacked Line"))
         .tooltip(Tooltip::new().trigger(Trigger::Axis))
-        .legend(Legend::new().data(vec![
-            "Email",
-            "Union Ads",
-            "Video Ads",
-            "Direct",
-            "Search Engine",
-        ]))
+        .legend(
+            Legend::new()
+                .data(vec![
+                    "Email",
+                    "Union Ads",
+                    "Video Ads",
+                    "Direct",
+                    "Search Engine",
+                    "Affiliate Marketing",
+                ])
+                .selected([("Affiliate Marketing", false)]),
+        )
         .grid(
             Grid::new()
                 .left("3%")
@@ -60,5 +65,11 @@ pub fn chart() -> Chart {
                 .name("Search Engine")
                 .stack("Total")
                 .data(vec![820, 932, 901, 934, 1290, 1330, 1320]),
+        )
+        .series(
+            Line::new()
+                .name("Affiliate Marketing")
+                .stack("Total")
+                .data(vec![180, 232, 210, 290, 250, 400, 370]),
         )
 }


### PR DESCRIPTION
Allows use of [selected](https://echarts.apache.org/en/option.html#legend.selected) in legend, so a given series can be unselected by default.

I also amended an example to show it in action:
![image](https://github.com/user-attachments/assets/e5ca338b-3c59-4119-b10e-b5c45bd6c2d6)
