### PR TITLE
Allow plotting series with null values

### DIFF
--- a/charming/src/datatype/value.rs
+++ b/charming/src/datatype/value.rs
@@ -35,6 +35,7 @@ impl From<f64> for NumericValue {
 #[serde(untagged)]
 pub enum CompositeValue {
     Number(NumericValue),
+    OptionalNumber(Option<NumericValue>),
     String(String),
     Array(Vec<CompositeValue>),
 }
@@ -45,6 +46,15 @@ where
 {
     fn from(n: N) -> Self {
         CompositeValue::Number(n.into())
+    }
+}
+
+impl<N> From<Option<N>> for CompositeValue
+where
+    N: Into<NumericValue>,
+{
+    fn from(n: Option<N>) -> Self {
+        CompositeValue::OptionalNumber(n.map(Into::into))
     }
 }
 

--- a/charming/src/series/line.rs
+++ b/charming/src/series/line.rs
@@ -54,6 +54,9 @@ pub struct Line {
     smooth: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    connect_nulls: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     mark_point: Option<MarkPoint>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -101,6 +104,7 @@ impl Line {
             item_style: None,
             emphasis: None,
             smooth: None,
+            connect_nulls: None,
             mark_point: None,
             mark_line: None,
             mark_area: None,
@@ -176,6 +180,11 @@ impl Line {
     /// Smoothness.
     pub fn smooth<F: Into<f64>>(mut self, smooth: F) -> Self {
         self.smooth = Some(smooth.into());
+        self
+    }
+
+    pub fn connect_nulls(mut self, connect_nulls: bool) -> Self {
+        self.connect_nulls = Some(connect_nulls);
         self
     }
 

--- a/gallery/src/line/distribution_of_electricity.rs
+++ b/gallery/src/line/distribution_of_electricity.rs
@@ -52,9 +52,28 @@ pub fn chart() -> Chart {
             Line::new()
                 .name("Electricity")
                 .smooth(0.5)
+                .connect_nulls(true)
                 .data(vec![
-                    300, 280, 250, 260, 270, 300, 550, 500, 400, 390, 380, 390, 400, 500, 600, 750,
-                    800, 700, 600, 400,
+                    Some(300),
+                    Some(280),
+                    Some(250),
+                    None,
+                    Some(270),
+                    Some(300),
+                    Some(550),
+                    Some(500),
+                    Some(400),
+                    Some(390),
+                    Some(380),
+                    Some(390),
+                    Some(400),
+                    Some(500),
+                    Some(600),
+                    Some(750),
+                    Some(800),
+                    Some(700),
+                    Some(600),
+                    Some(400),
                 ])
                 .mark_area(
                     MarkArea::new()


### PR DESCRIPTION
1) add Option\<NumericValue> to CompositeValue
2) add [connectNulls](https://echarts.apache.org/en/option.html#series-line.connectNulls) to Line

with these changes you can make line charts containing empty data and connect the remaining points. 

I've amended an example to show this: 
![image](https://github.com/user-attachments/assets/43cd36c3-78b1-4f6b-821f-c0d54be6ed6a)

 