### PR TITLE
Implement Display instead of ToString for Chart

### DIFF
--- a/charming/src/lib.rs
+++ b/charming/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::to_string_trait_impl)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 /*!
 Charming is a powerful and versatile chart rendering library for Rust that
@@ -516,9 +515,13 @@ impl Chart {
     }
 }
 
-impl ToString for Chart {
-    fn to_string(&self) -> String {
-        process_raw_strings(serde_json::to_string_pretty(self).unwrap().as_str())
+impl std::fmt::Display for Chart {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            process_raw_strings(&serde_json::to_string_pretty(self).unwrap())
+        )
     }
 }
 


### PR DESCRIPTION
[Corresponding clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#/to_string_trait_impl)