### PR TITLE
Add useful derive traits

### DIFF
--- a/charming/src/component/angle_axis.rs
+++ b/charming/src/component/angle_axis.rs
@@ -6,7 +6,7 @@ use crate::element::{
 };
 
 /// The angle axis in Polar Coordinate.
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AngleAxis {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/aria.rs
+++ b/charming/src/component/aria.rs
@@ -8,7 +8,7 @@ use crate::{
 /**
 A single decal pattern.
  */
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DecalItem {
     /// The symbol type of the decal.
@@ -132,7 +132,7 @@ impl DecalItem {
 /**
 Decal patterns to be applied to series data.
  */
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Decal {
     /// Whether to show decal patterns. If `decals` is not set, this option is
@@ -202,7 +202,7 @@ Chart::new()
     .series(Bar::new().data(vec![140, 230, 120, 50, 30, 150, 120]));
 ```
  */
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Aria {
     /// Whether to enable WAI-ARIA.

--- a/charming/src/component/axis.rs
+++ b/charming/src/component/axis.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Axis in cartesian coordinate.
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Axis {
     /// Type of axis.

--- a/charming/src/component/axis3d.rs
+++ b/charming/src/component/axis3d.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::element::AxisType;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Axis3D {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/data_zoom.rs
+++ b/charming/src/component/data_zoom.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{Color, DataBackground, Orient, TextStyle},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum FilterMode {
     Filter,
@@ -14,7 +14,7 @@ pub enum FilterMode {
     None,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum DataZoomType {
     Inside,
@@ -25,7 +25,7 @@ pub enum DataZoomType {
 /// DataZoom component is used for zooming a specific area, which enables user
 /// to investigate data in detail, or get an overview of the data, or get rid
 /// of outlier points.
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataZoom {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/geo_map.rs
+++ b/charming/src/component/geo_map.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 pub enum GeoMapOpt {
     #[serde(rename = "geoJSON")]
     GeoJson {
@@ -20,7 +20,7 @@ where
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GeoMap {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/grid.rs
+++ b/charming/src/component/grid.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{Color, Padding, TextStyle, Trigger},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GridTooltip {
     /// Whether to show the tooltip component.
@@ -133,7 +133,7 @@ impl GridTooltip {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Grid {
     /// Component ID.

--- a/charming/src/component/grid3d.rs
+++ b/charming/src/component/grid3d.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Grid3D {}
 

--- a/charming/src/component/legend.rs
+++ b/charming/src/component/legend.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{Color, Icon, ItemStyle, LabelAlign, LineStyle, Orient, Padding, TextStyle},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum LegendType {
     /// Simple legend.
@@ -15,7 +15,7 @@ pub enum LegendType {
     Scroll,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum LegendSelectedMode {
     /// Multiple selection.
@@ -25,7 +25,7 @@ pub enum LegendSelectedMode {
     Single,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LegendItem {
     pub name: String,
@@ -67,7 +67,7 @@ impl From<(String, String)> for LegendItem {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Legend {
     /// Type of legend.

--- a/charming/src/component/parallel_axis.rs
+++ b/charming/src/component/parallel_axis.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::element::{AxisType, NameLocation};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ParallelAxis {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/parallel_coordinate.rs
+++ b/charming/src/component/parallel_coordinate.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ParallelAxisDefault {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -233,7 +233,7 @@ impl ParallelAxisDefault {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ParallelCoordinate {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/polar_coordinate.rs
+++ b/charming/src/component/polar_coordinate.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use crate::datatype::CompositeValue;
 
 /// Polar coordinate can be used in scatter and line chart.
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PolarCoordinate {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/radar_coordinate.rs
+++ b/charming/src/component/radar_coordinate.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// Name options for radar indicators.
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadarAxisName {
     /// Whether to display the indicator's name.
@@ -297,7 +297,7 @@ impl RadarAxisName {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadarIndicator {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -372,7 +372,7 @@ impl From<(&str, i64, i64)> for RadarIndicator {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadarCoordinate {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/radius_axis.rs
+++ b/charming/src/component/radius_axis.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use crate::element::{AxisLabel, AxisLine, AxisType, BoundaryGap, NameLocation, TextStyle};
 
 /// Radius axis in polar coordinate.
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadiusAxis {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/single_axis.rs
+++ b/charming/src/component/single_axis.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{datatype::CompositeValue, element::Orient};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum Type {
     Value,
@@ -11,7 +11,7 @@ pub enum Type {
     Log,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SingleAxis {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/title.rs
+++ b/charming/src/component/title.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// Title component, including main title and subtitle.
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Title {
     /// Component ID.

--- a/charming/src/component/toolbox.rs
+++ b/charming/src/component/toolbox.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{datatype::CompositeValue, element::Orient};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum SaveAsImageType {
     Png,
@@ -10,7 +10,7 @@ pub enum SaveAsImageType {
     Svg,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SaveAsImage {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -64,7 +64,7 @@ impl SaveAsImage {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Restore {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -99,7 +99,7 @@ impl Restore {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataView {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -143,7 +143,7 @@ impl DataView {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum MagicTypeType {
     /// For line charts.
@@ -165,7 +165,7 @@ impl From<&str> for MagicTypeType {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MagicType {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -200,7 +200,7 @@ impl MagicType {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum BrushType {
     Rect,
@@ -211,7 +211,7 @@ pub enum BrushType {
     Clear,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Brush {
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -235,7 +235,7 @@ impl Brush {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolboxDataZoom {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -259,7 +259,7 @@ impl ToolboxDataZoom {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Feature {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -330,7 +330,7 @@ impl Feature {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Toolbox {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/visual_map.rs
+++ b/charming/src/component/visual_map.rs
@@ -5,14 +5,14 @@ use crate::{
     element::{Color, Orient, TextStyle},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum VisualMapType {
     Continuous,
     Piecewise,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VisualMapPiece {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -125,7 +125,7 @@ impl From<(i64, i64, &str)> for VisualMapPiece {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VisualMapChannel {
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -149,7 +149,7 @@ impl VisualMapChannel {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VisualMap {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/datatype/datapoint.rs
+++ b/charming/src/datatype/datapoint.rs
@@ -6,7 +6,7 @@ use crate::element::ItemStyle;
 
 use super::CompositeValue;
 
-#[derive(Serialize)]
+#[derive(Serialize, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataPointItem {
     value: CompositeValue,
@@ -72,7 +72,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(untagged)]
 pub enum DataPoint {
     Value(CompositeValue),

--- a/charming/src/datatype/dataset.rs
+++ b/charming/src/datatype/dataset.rs
@@ -4,7 +4,7 @@ use crate::element::RawString;
 
 use super::{DataSource, Dimension};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 pub struct Source {
     source: DataSource,
 
@@ -62,7 +62,7 @@ where
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Transform {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -130,6 +130,7 @@ impl From<&str> for Transform {
     }
 }
 
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub struct Dataset {
     sources: Vec<Source>,
     transforms: Vec<Transform>,

--- a/charming/src/datatype/dimension.rs
+++ b/charming/src/datatype/dimension.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(untagged)]
 pub enum DimensionType {
     Number,
@@ -23,7 +23,7 @@ impl From<&str> for DimensionType {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Dimension {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/anchor.rs
+++ b/charming/src/element/anchor.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::{icon::Icon, item_style::ItemStyle};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Anchor {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/area_style.rs
+++ b/charming/src/element/area_style.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::color::Color;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum OriginPosition {
     Auto,
@@ -10,7 +10,7 @@ pub enum OriginPosition {
     End,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AreaStyle {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/axis_label.rs
+++ b/charming/src/element/axis_label.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::{color::Color, Formatter};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisLabel {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/axis_line.rs
+++ b/charming/src/element/axis_line.rs
@@ -2,6 +2,7 @@ use serde::{ser::SerializeSeq, Serialize};
 
 use super::color::Color;
 
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub struct ColorSegment(f64, Color);
 
 impl Serialize for ColorSegment {
@@ -25,7 +26,7 @@ impl From<(f64, Color)> for ColorSegment {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisLineStyle {
     color: Vec<ColorSegment>,
@@ -116,7 +117,7 @@ impl From<(f64, &str, f64)> for AxisLineStyle {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisLine {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/axis_pointer.rs
+++ b/charming/src/element/axis_pointer.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{Label, LineStyle},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum AxisPointerType {
     Line,
@@ -14,7 +14,7 @@ pub enum AxisPointerType {
     None,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum AxisPointerAxis {
     X,
@@ -23,7 +23,7 @@ pub enum AxisPointerAxis {
     Angle,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisPointerLink {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -78,7 +78,7 @@ impl AxisPointerLink {
 
 /// Axis Pointer is a tool for displaying reference line and axis value under
 /// mouse pointer.
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisPointer {
     /// Component ID.

--- a/charming/src/element/axis_tick.rs
+++ b/charming/src/element/axis_tick.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::line_style::LineStyle;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisTick {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/axis_type.rs
+++ b/charming/src/element/axis_type.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 /// Type of axis.
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum AxisType {
     /// Numerical axis, suitable for continuous data.

--- a/charming/src/element/background.rs
+++ b/charming/src/element/background.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::{area_style::AreaStyle, border_type::BorderType, color::Color, line_style::LineStyle};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BackgroundStyle {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -73,7 +73,7 @@ impl BackgroundStyle {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataBackground {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/blur.rs
+++ b/charming/src/element/blur.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::{item_style::ItemStyle, label::Label};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Blur {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/border_type.rs
+++ b/charming/src/element/border_type.rs
@@ -1,6 +1,6 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum BorderType {
     Solid,

--- a/charming/src/element/boundary_gap.rs
+++ b/charming/src/element/boundary_gap.rs
@@ -9,6 +9,7 @@ use serde::{ser::SerializeSeq, Serialize};
 /// For non-category axis, including time, numerical value, and log axes,
 /// `BoundaryGap` is an array of two values, representing the spanning range
 /// between minimum and maximum value.
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum BoundaryGap {
     CategoryAxis(bool),
     NonCategoryAxis(String, String),

--- a/charming/src/element/color.rs
+++ b/charming/src/element/color.rs
@@ -1,7 +1,7 @@
 use serde::ser::{SerializeStruct, Serializer};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum ColorBy {
     Series,
@@ -18,7 +18,7 @@ impl From<&str> for ColorBy {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 pub struct ColorStop {
     offset: f64,
     color: String,
@@ -33,7 +33,7 @@ impl ColorStop {
     }
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 pub enum Color {
     Value(String),
     LinearGradient {

--- a/charming/src/element/coordinate.rs
+++ b/charming/src/element/coordinate.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum CoordinateSystem {
     Cartesian2d,

--- a/charming/src/element/cursor.rs
+++ b/charming/src/element/cursor.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum Cursor {
     Pointer,

--- a/charming/src/element/dimension_encode.rs
+++ b/charming/src/element/dimension_encode.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::datatype::CompositeValue;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DimensionEncode {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/emphasis.rs
+++ b/charming/src/element/emphasis.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::{item_style::ItemStyle, AreaStyle, Label};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum EmphasisFocus {
     None,
@@ -15,7 +15,7 @@ pub enum EmphasisFocus {
     Adjacency,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Emphasis {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/formatter.rs
+++ b/charming/src/element/formatter.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::RawString;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(untagged)]
 pub enum Formatter {
     String(String),

--- a/charming/src/element/icon.rs
+++ b/charming/src/element/icon.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum Icon {
     Circle,
     Rect,

--- a/charming/src/element/item_style.rs
+++ b/charming/src/element/item_style.rs
@@ -1,7 +1,7 @@
-use serde::{Serialize, Deserialize};
 use super::{border_type::BorderType, color::Color};
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ItemStyle {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/label.rs
+++ b/charming/src/element/label.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::{color::Color, line_style::LineStyle, Formatter};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum LabelPosition {
     Top,
@@ -24,7 +24,7 @@ pub enum LabelPosition {
     Center,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum LabelAlign {
     Left,
@@ -32,7 +32,7 @@ pub enum LabelAlign {
     Right,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum LabelVerticalAlign {
     Top,
@@ -40,7 +40,7 @@ pub enum LabelVerticalAlign {
     Bottom,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Label {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -233,7 +233,7 @@ impl Label {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LabelLine {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -304,7 +304,7 @@ impl LabelLine {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LabelLayout {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/line_style.rs
+++ b/charming/src/element/line_style.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::color::Color;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum LineStyleType {
     Solid,
@@ -10,7 +10,7 @@ pub enum LineStyleType {
     Dotted,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LineStyle {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/link_target.rs
+++ b/charming/src/element/link_target.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum LinkTarget {
     #[serde(rename = "self")]

--- a/charming/src/element/mark_area.rs
+++ b/charming/src/element/mark_area.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::{blur::Blur, emphasis::Emphasis, item_style::ItemStyle, label::Label};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkAreaData {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -46,7 +46,7 @@ impl MarkAreaData {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkArea {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/mark_line.rs
+++ b/charming/src/element/mark_line.rs
@@ -4,7 +4,7 @@ use crate::datatype::CompositeValue;
 
 use super::{label::Label, line_style::LineStyle, symbol::Symbol};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum MarkLineDataType {
     Min,
@@ -25,7 +25,7 @@ impl From<&str> for MarkLineDataType {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkLineData {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -130,6 +130,7 @@ impl From<(&str, &str)> for MarkLineData {
     }
 }
 
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum MarkLineVariant {
     Simple(MarkLineData),
     StartToEnd(MarkLineData, MarkLineData),
@@ -149,7 +150,7 @@ impl Serialize for MarkLineVariant {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkLine {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/mark_point.rs
+++ b/charming/src/element/mark_point.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum MarkPointDataType {
     Min,
@@ -19,7 +19,7 @@ impl From<&str> for MarkPointDataType {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkPointData {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -88,7 +88,7 @@ impl From<(&str, &str)> for MarkPointData {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkPoint {
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/charming/src/element/minor_split_line.rs
+++ b/charming/src/element/minor_split_line.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::line_style::LineStyle;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MinorSplitLine {
     show: Option<bool>,

--- a/charming/src/element/minor_tick.rs
+++ b/charming/src/element/minor_tick.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::line_style::LineStyle;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MinorTick {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/name_location.rs
+++ b/charming/src/element/name_location.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum NameLocation {
     Start,

--- a/charming/src/element/orient.rs
+++ b/charming/src/element/orient.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum Orient {
     Horizontal,

--- a/charming/src/element/padding.rs
+++ b/charming/src/element/padding.rs
@@ -1,6 +1,7 @@
 use serde::{ser::SerializeSeq, Serialize};
 
 /// Padding space around content.
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum Padding {
     /// Set padding of all sides.
     Single(f64),

--- a/charming/src/element/parallel_layout.rs
+++ b/charming/src/element/parallel_layout.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum ParallelLayout {
     Horizontal,

--- a/charming/src/element/pointer.rs
+++ b/charming/src/element/pointer.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::{icon::Icon, item_style::ItemStyle};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Pointer {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/raw_string.rs
+++ b/charming/src/element/raw_string.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 pub static RAW_MARK: &str = "#*#*#*#";
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub struct RawString(String);
 
 impl Serialize for RawString {

--- a/charming/src/element/scale_limit.rs
+++ b/charming/src/element/scale_limit.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ScaleLimit {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/select.rs
+++ b/charming/src/element/select.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::{item_style::ItemStyle, label::Label};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Select {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/shape.rs
+++ b/charming/src/element/shape.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum Shape {
     Polygon,

--- a/charming/src/element/sort.rs
+++ b/charming/src/element/sort.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum Sort {
     Ascending,
     Descending,

--- a/charming/src/element/split_area.rs
+++ b/charming/src/element/split_area.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SplitArea {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/split_line.rs
+++ b/charming/src/element/split_line.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::line_style::LineStyle;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SplitLine {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/symbol.rs
+++ b/charming/src/element/symbol.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum Symbol {
     Circle,
     Rect,

--- a/charming/src/element/symbol_size.rs
+++ b/charming/src/element/symbol_size.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::RawString;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(untagged)]
 pub enum SymbolSize {
     Number(f64),

--- a/charming/src/element/text_align.rs
+++ b/charming/src/element/text_align.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum TextAlign {
     Auto,
@@ -9,7 +9,7 @@ pub enum TextAlign {
     Center,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum TextVerticalAlign {
     Auto,

--- a/charming/src/element/text_style.rs
+++ b/charming/src/element/text_style.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::color::Color;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TextStyle {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -25,7 +25,7 @@ pub struct TextStyle {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     align: Option<String>,
-    
+
     #[serde(skip_serializing_if = "Option::is_none")]
     padding: Option<[f64; 4]>,
 }

--- a/charming/src/element/tooltip.rs
+++ b/charming/src/element/tooltip.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::element::{AxisPointer, Color, Formatter, Padding};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum TriggerOn {
     Mousemove,
@@ -13,7 +13,7 @@ pub enum TriggerOn {
 }
 
 /// Types of triggering.
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum Trigger {
     Item,
@@ -21,7 +21,7 @@ pub enum Trigger {
     None,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Tooltip {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/lib.rs
+++ b/charming/src/lib.rs
@@ -237,7 +237,7 @@ mouse pointer.
 [`Toolbox`] is a feature toolbox that includes data view, save as image, data
 zoom, restore, and reset.
  */
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Chart {
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/charming/src/series/bar.rs
+++ b/charming/src/series/bar.rs
@@ -7,7 +7,7 @@ use crate::{
     element::{BackgroundStyle, ColorBy, CoordinateSystem, Emphasis, ItemStyle, Label, MarkLine},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Bar {
     #[serde(rename = "type")]

--- a/charming/src/series/bar3d.rs
+++ b/charming/src/series/bar3d.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{CoordinateSystem, DimensionEncode},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 pub struct Bar3d {
     #[serde(rename = "type")]
     type_: String,

--- a/charming/src/series/boxplot.rs
+++ b/charming/src/series/boxplot.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::element::{ColorBy, CoordinateSystem};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Boxplot {
     #[serde(rename = "type")]

--- a/charming/src/series/candlestick.rs
+++ b/charming/src/series/candlestick.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{ColorBy, CoordinateSystem},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Candlestick {
     #[serde(rename = "type")]

--- a/charming/src/series/custom.rs
+++ b/charming/src/series/custom.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Custom {
     type_: String,

--- a/charming/src/series/effect_scatter.rs
+++ b/charming/src/series/effect_scatter.rs
@@ -8,27 +8,27 @@ use crate::{
     },
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum EffectType {
     Ripple,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum ShowEffectOn {
     Render,
     Emphasis,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum RippleEffectBrushType {
     Fill,
     Stroke,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RippleEffect {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -90,7 +90,7 @@ impl RippleEffect {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EffectScatter {
     #[serde(rename = "type")]

--- a/charming/src/series/funnel.rs
+++ b/charming/src/series/funnel.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{ColorBy, Emphasis, ItemStyle, Label, LabelLine, Orient, Sort},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum Align {
     Left,
@@ -13,7 +13,7 @@ pub enum Align {
     Center,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Funnel {
     #[serde(rename = "type")]

--- a/charming/src/series/gauge.rs
+++ b/charming/src/series/gauge.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GaugeDetail {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -106,7 +106,7 @@ impl GaugeDetail {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GaugeTitle {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -141,7 +141,7 @@ impl GaugeTitle {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GaugeProgress {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -212,7 +212,7 @@ impl GaugeProgress {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Gauge {
     #[serde(rename = "type")]

--- a/charming/src/series/graph.rs
+++ b/charming/src/series/graph.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::element::{CoordinateSystem, Label, LabelLayout, LineStyle, ScaleLimit};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphLayoutCircular {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -26,7 +26,7 @@ impl GraphLayoutCircular {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphLayoutForce {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -88,7 +88,7 @@ impl GraphLayoutForce {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum GraphLayout {
     None,
@@ -107,7 +107,7 @@ impl From<&str> for GraphLayout {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphNodeLabel {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -169,7 +169,7 @@ impl GraphNodeLabel {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphNode {
     pub id: String,
@@ -184,7 +184,7 @@ pub struct GraphNode {
     pub label: Option<GraphNodeLabel>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphLink {
     pub source: String,
@@ -193,13 +193,13 @@ pub struct GraphLink {
     pub value: Option<f64>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphCategory {
     pub name: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphData {
     pub nodes: Vec<GraphNode>,
@@ -207,7 +207,7 @@ pub struct GraphData {
     pub categories: Vec<GraphCategory>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Graph {
     #[serde(rename = "type")]

--- a/charming/src/series/heatmap.rs
+++ b/charming/src/series/heatmap.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{CoordinateSystem, Emphasis, ItemStyle, Label},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Heatmap {
     #[serde(rename = "type")]

--- a/charming/src/series/line.rs
+++ b/charming/src/series/line.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Line {
     #[serde(rename = "type")]

--- a/charming/src/series/map.rs
+++ b/charming/src/series/map.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Map {}

--- a/charming/src/series/mod.rs
+++ b/charming/src/series/mod.rs
@@ -50,6 +50,7 @@ pub use theme_river::*;
 pub use tree::*;
 pub use treemap::*;
 
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum Series {
     Bar(bar::Bar),
     Bar3d(bar3d::Bar3d),

--- a/charming/src/series/parallel.rs
+++ b/charming/src/series/parallel.rs
@@ -5,14 +5,14 @@ use crate::{
     element::{ColorBy, CoordinateSystem, Emphasis, LineStyle},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum ProgressiveChunkMode {
     Sequential,
     Mod,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Parallel {
     #[serde(rename = "type")]

--- a/charming/src/series/pictorial_bar.rs
+++ b/charming/src/series/pictorial_bar.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PictorialBar {
     #[serde(rename = "type")]

--- a/charming/src/series/pie.rs
+++ b/charming/src/series/pie.rs
@@ -5,14 +5,14 @@ use crate::{
     element::{ColorBy, CoordinateSystem, Emphasis, ItemStyle, Label, LabelLine},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum PieRoseType {
     Radius,
     Area,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Pie {
     #[serde(rename = "type")]

--- a/charming/src/series/radar.rs
+++ b/charming/src/series/radar.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{AreaStyle, ColorBy, Emphasis, LineStyle, Symbol, Tooltip},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Radar {
     #[serde(rename = "type")]

--- a/charming/src/series/sankey.rs
+++ b/charming/src/series/sankey.rs
@@ -2,10 +2,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
-    element::{Emphasis, Label, LineStyle, Orient, ItemStyle},
+    element::{Emphasis, ItemStyle, Label, LineStyle, Orient},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum SankeyNodeAlign {
     Left,
@@ -13,7 +13,7 @@ pub enum SankeyNodeAlign {
     Justify,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SankeyNode {
     pub name: String,
@@ -29,7 +29,10 @@ pub struct SankeyNode {
 }
 
 impl SankeyNode {
-    pub fn new<S>(name: S) -> Self where S: Into<String> {
+    pub fn new<S>(name: S) -> Self
+    where
+        S: Into<String>,
+    {
         Self {
             name: name.into(),
             value: None,
@@ -54,8 +57,8 @@ impl SankeyNode {
 }
 
 impl<S> From<S> for SankeyNode
-    where
-        S: Into<String>,
+where
+    S: Into<String>,
 {
     fn from(name: S) -> Self {
         SankeyNode {
@@ -67,7 +70,7 @@ impl<S> From<S> for SankeyNode
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SankeyLink {
     pub source: String,
@@ -89,7 +92,7 @@ where
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Sankey {
     #[serde(rename = "type")]

--- a/charming/src/series/scatter.rs
+++ b/charming/src/series/scatter.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Scatter {
     #[serde(rename = "type")]

--- a/charming/src/series/sunburst.rs
+++ b/charming/src/series/sunburst.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::element::{Emphasis, ItemStyle, Label, Sort};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SunburstLevel {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -55,7 +55,7 @@ impl SunburstLevel {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SunburstNode {
     name: String,
@@ -117,7 +117,7 @@ impl From<(&str, f64, &str)> for SunburstNode {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Sunburst {
     #[serde(rename = "type")]

--- a/charming/src/series/theme_river.rs
+++ b/charming/src/series/theme_river.rs
@@ -5,6 +5,7 @@ use crate::{
     element::{BoundaryGap, ColorBy, CoordinateSystem, Label},
 };
 
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub struct ThemeRiverData {
     date: CompositeValue,
     value: CompositeValue,
@@ -47,7 +48,7 @@ where
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ThemeRiver {
     #[serde(rename = "type")]

--- a/charming/src/series/tree.rs
+++ b/charming/src/series/tree.rs
@@ -5,14 +5,14 @@ use crate::{
     element::{Blur, Emphasis, ItemStyle, Label, Select, Symbol},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum TreeLayout {
     Orthogonal,
     Radial,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 pub enum TreeOrient {
     #[serde(rename = "LR")]
     LeftRight,
@@ -24,14 +24,14 @@ pub enum TreeOrient {
     BottomTop,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum TreeEdgeShape {
     Curve,
     Polyline,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TreeLeaves {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -55,7 +55,7 @@ impl TreeLeaves {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TreeNode {
     pub name: String,
@@ -71,7 +71,7 @@ pub struct TreeNode {
 }
 
 /// The tree diagram is mainly used to display the tree data structure.
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Tree {
     #[serde(rename = "type")]

--- a/charming/src/series/treemap.rs
+++ b/charming/src/series/treemap.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{Emphasis, ItemStyle, Label},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Treemap {
     #[serde(rename = "type")]

--- a/gallery/src/line/line_gradient.rs
+++ b/gallery/src/line/line_gradient.rs
@@ -99,11 +99,7 @@ pub fn chart() -> Chart {
                 .max((data_list.len() - 1) as f64),
         )
         .x_axis(Axis::new().data(data_list.to_vec()))
-        .x_axis(
-            Axis::new()
-                .data(data_list.to_vec())
-                .grid_index(1),
-        )
+        .x_axis(Axis::new().data(data_list.to_vec()).grid_index(1))
         .y_axis(Axis::new())
         .y_axis(Axis::new().grid_index(1))
         .grid(Grid::new().bottom("60%"))


### PR DESCRIPTION
Added normal useful traits on `Chart` and all affected parts that needed it. Deriving these useful traits makes it a lot easier to work with charming in a more dynamic context like wasm. Deriving these traits has no downside but we should try our best to not remove them in the future, but with most of the functionality already implemented I think this won't be a problem. 

We are unable to derive `PartialOrd` on `Chart` because we can not derive `PartialOrd` on `GeoMapOpt`. `GeoMapOpt` contains the type `serde_json::Value` which does not implement `PartialOrd`. I don't know how we would go about circumventing that but I also don't think users of the library expect or need `PartialOrd` on the complete Chart. If a user needs `PartialOrd` on `Chart` we can look at that again.

i will rebase this PR after we merge #85 and #77. 
This PR will close these issues: fix #27, fix #35, fix #41
Implements some parts of #58 