### PR TITLE
Fix ssr not rendering many points

### DIFF
--- a/charming/src/renderer/image_renderer.rs
+++ b/charming/src/renderer/image_renderer.rs
@@ -19,7 +19,7 @@ var chart = echarts.init(null, {{#if theme}}'{{ theme }}'{{else}}null{{/if}}, {
     height: {{ height }}
 });
 
-chart.setOption({ animation: false });
+chart.setOption({ animation: false, progressive: 0 });
 chart.setOption({{{ chart_option }}});
 chart.renderToSVGString();
 "#;


### PR DESCRIPTION
Will fix #20 

A rendering optimization in echarts will prevent all values from being rendered at once if the amount of values exceed a given threshold. We can override this behavior when we set progressive to 0; [echart docs](https://echarts.apache.org/en/option.html#series-scatter.progressive)

