### PR TITLE
add symbol callback

### DIFF
--- a/charming/src/element/symbol.rs
+++ b/charming/src/element/symbol.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 
+use super::RawString;
+
 pub enum Symbol {
     Circle,
     Rect,
@@ -10,6 +12,7 @@ pub enum Symbol {
     Arrow,
     None,
     Custom(String),
+    Callback(RawString),
 }
 
 impl Serialize for Symbol {
@@ -24,6 +27,7 @@ impl Serialize for Symbol {
             Symbol::Arrow => serializer.serialize_str("arrow"),
             Symbol::None => serializer.serialize_str("none"),
             Symbol::Custom(s) => serializer.serialize_str(s),
+            Symbol::Callback(s) => s.serialize(serializer),
         }
     }
 }


### PR DESCRIPTION
I would like to propose a PR that adds support for setting the symbol using a callback function, as described in the ECharts documentation regarding [symbol](https://echarts.apache.org/en/option.html#series-line.symbol). Currently, the Symbol structure in the code does not support this method. Therefore, I have introduced a Callback enum to accommodate this functionality.