### PR TITLE
add end_angle to angle_axis

### DIFF
--- a/charming/src/component/angle_axis.rs
+++ b/charming/src/component/angle_axis.rs
@@ -24,6 +24,9 @@ pub struct AngleAxis {
     #[serde(skip_serializing_if = "Option::is_none")]
     start_angle: Option<f64>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end_angle: Option<f64>,
+
     /// Whether the direction of axis is clockwise, default to true.
     #[serde(skip_serializing_if = "Option::is_none")]
     clockwise: Option<bool>,
@@ -112,6 +115,7 @@ impl AngleAxis {
             id: None,
             polar_index: None,
             start_angle: None,
+            end_angle: None,
             clockwise: None,
             type_: None,
             zlevel: None,
@@ -155,6 +159,11 @@ impl AngleAxis {
 
     pub fn start_angle<F: Into<f64>>(mut self, start_angle: F) -> Self {
         self.start_angle = Some(start_angle.into());
+        self
+    }
+
+    pub fn end_angle<F: Into<f64>>(mut self, end_angle: F) -> Self {
+        self.end_angle = Some(end_angle.into());
         self
     }
 


### PR DESCRIPTION
Adds `end_angle` to `angle_axis`. The feature was added in `5.5.0` and allows for polar slices. Will close #36 

Example
```rust
Chart::new()
    .polar(PolarCoordinate::new())
    .tooltip(Tooltip::new())
    .angle_axis(
        AngleAxis::new()
            .type_(AxisType::Category)
            .end_angle(-180)
            .data(vec!["S1", "S2", "S3"]),
    )
    .radius_axis(RadiusAxis::new())
    .series(
        Bar::new()
            .coordinate_system(CoordinateSystem::Polar)
            .data(vec![1, 2, 3]),
    );
```

Will create this example plot [polar-end-angle](https://echarts.apache.org/examples/en/editor.html?c=doc-example%2Fpolar-end-angle&edit=1&reset=1)