### PR TITLE
fix line symbol_size param type

### DIFF
--- a/charming/src/series/line.rs
+++ b/charming/src/series/line.rs
@@ -4,7 +4,7 @@ use crate::{
     datatype::{DataFrame, DataPoint},
     element::{
         smoothness::Smoothness, AreaStyle, CoordinateSystem, DimensionEncode, Emphasis, ItemStyle,
-        Label, LineStyle, MarkArea, MarkLine, MarkPoint, Symbol,
+        Label, LineStyle, MarkArea, MarkLine, MarkPoint, Symbol, SymbolSize,
     },
 };
 
@@ -27,7 +27,7 @@ pub struct Line {
     symbol: Option<Symbol>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    symbol_size: Option<f64>,
+    symbol_size: Option<SymbolSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     show_symbol: Option<bool>,
@@ -137,7 +137,7 @@ impl Line {
         self
     }
 
-    pub fn symbol_size<F: Into<f64>>(mut self, symbol_size: F) -> Self {
+    pub fn symbol_size<F: Into<SymbolSize>>(mut self, symbol_size: F) -> Self {
         self.symbol_size = Some(symbol_size.into());
         self
     }

--- a/gallery/src/line/different_symbols.rs
+++ b/gallery/src/line/different_symbols.rs
@@ -1,6 +1,6 @@
 use charming::{
     component::Axis,
-    element::{AxisType, Symbol},
+    element::{AxisType, Symbol, SymbolSize},
     series::Line,
     Chart,
 };
@@ -14,6 +14,6 @@ pub fn chart() -> Chart {
         )
         .y_axis(Axis::new().type_(AxisType::Value))
         .series(Line::new().data(vec![150, 230, 224, 218, 135, 147, 260])
-        .symbol_size(20)
+        .symbol_size(SymbolSize::Function("function (value, params) { return params.dataIndex % 2 === 0 ? value > 200 ? 10 : 20 : 30; }".into()))
         .symbol(Symbol::Callback("function (value, params) { return params.dataIndex % 2 === 0 ? value > 200 ? 'diamond' : 'circle' : 'triangle'; }".into())))
 }


### PR DESCRIPTION
The symbol_size method in Line should accept a function as a parameter. However, the current implementation uses a fixed f64, which limits the ability to dynamically customize the symbol size. 
I added related example in gallery/src/line/different_symbols.rs:
![image](https://github.com/user-attachments/assets/243298a6-9400-4507-b764-161dfc42bad0)

