### PR TITLE
Add some missing fields

### DIFF
--- a/charming/src/element/mark_line.rs
+++ b/charming/src/element/mark_line.rs
@@ -168,6 +168,9 @@ pub struct MarkLine {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     symbol: Vec<Symbol>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    precision: Option<f64>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<MarkLineVariant>,
 }
@@ -186,6 +189,7 @@ impl MarkLine {
             zlevel: None,
             z: None,
             symbol: vec![],
+            precision: None,
             data: vec![],
         }
     }
@@ -212,6 +216,11 @@ impl MarkLine {
 
     pub fn symbol<S: Into<Symbol>>(mut self, symbol: Vec<S>) -> Self {
         self.symbol = symbol.into_iter().map(|s| s.into()).collect();
+        self
+    }
+
+    pub fn precision<F: Into<f64>>(mut self, precision: F) -> Self {
+        self.precision = Some(precision.into());
         self
     }
 

--- a/charming/src/element/mark_line.rs
+++ b/charming/src/element/mark_line.rs
@@ -171,6 +171,9 @@ pub struct MarkLine {
     #[serde(skip_serializing_if = "Option::is_none")]
     precision: Option<f64>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    silent: Option<bool>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<MarkLineVariant>,
 }
@@ -190,6 +193,7 @@ impl MarkLine {
             z: None,
             symbol: vec![],
             precision: None,
+            silent: None,
             data: vec![],
         }
     }
@@ -221,6 +225,11 @@ impl MarkLine {
 
     pub fn precision<F: Into<f64>>(mut self, precision: F) -> Self {
         self.precision = Some(precision.into());
+        self
+    }
+
+    pub fn silent(mut self, silent: bool) -> Self {
+        self.silent = Some(silent);
         self
     }
 

--- a/charming/src/series/bar.rs
+++ b/charming/src/series/bar.rs
@@ -4,7 +4,9 @@ use serde::Serialize;
 
 use crate::{
     datatype::{DataFrame, DataPoint},
-    element::{BackgroundStyle, ColorBy, CoordinateSystem, Emphasis, ItemStyle, Label, MarkLine},
+    element::{
+        BackgroundStyle, ColorBy, CoordinateSystem, Emphasis, ItemStyle, Label, MarkLine, Tooltip,
+    },
 };
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
@@ -67,6 +69,9 @@ pub struct Bar {
     #[serde(skip_serializing_if = "Option::is_none")]
     bar_width: Option<f64>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }
@@ -99,6 +104,7 @@ impl Bar {
             mark_line: None,
             stack: None,
             bar_width: None,
+            tooltip: None,
             data: vec![],
         }
     }
@@ -190,6 +196,11 @@ impl Bar {
 
     pub fn bar_width<F: Into<f64>>(mut self, bar_width: F) -> Self {
         self.bar_width = Some(bar_width.into());
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/boxplot.rs
+++ b/charming/src/series/boxplot.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::element::{ColorBy, CoordinateSystem};
+use crate::element::{ColorBy, CoordinateSystem, Tooltip};
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -28,6 +28,9 @@ pub struct Boxplot {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     dataset_index: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
 }
 
 impl Default for Boxplot {
@@ -47,6 +50,7 @@ impl Boxplot {
             legend_hover_link: None,
             hover_animation: None,
             dataset_index: None,
+            tooltip: None,
         }
     }
 
@@ -82,6 +86,11 @@ impl Boxplot {
 
     pub fn dataset_index(mut self, dataset_index: u64) -> Self {
         self.dataset_index = Some(dataset_index);
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 }

--- a/charming/src/series/candlestick.rs
+++ b/charming/src/series/candlestick.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     datatype::{DataFrame, DataPoint},
-    element::{ColorBy, CoordinateSystem},
+    element::{ColorBy, CoordinateSystem, Tooltip},
 };
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
@@ -26,6 +26,9 @@ pub struct Candlestick {
     #[serde(skip_serializing_if = "Option::is_none")]
     legend_hover_link: Option<bool>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }
@@ -46,6 +49,7 @@ impl Candlestick {
             color_by: None,
             legend_hover_link: None,
             data: vec![],
+            tooltip: None,
         }
     }
 
@@ -71,6 +75,11 @@ impl Candlestick {
 
     pub fn legend_hover_link(mut self, legend_hover_link: bool) -> Self {
         self.legend_hover_link = Some(legend_hover_link);
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/custom.rs
+++ b/charming/src/series/custom.rs
@@ -4,6 +4,7 @@ use crate::{
     datatype::{CompositeValue, DataFrame, DataPoint, Dimension},
     element::{
         ColorBy, CoordinateSystem, DimensionEncode, ItemStyle, LabelLayout, LabelLine, RawString,
+        Tooltip,
     },
 };
 
@@ -63,6 +64,9 @@ pub struct Custom {
     #[serde(skip_serializing_if = "Option::is_none")]
     encode: Option<DimensionEncode>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }
@@ -94,6 +98,7 @@ impl Custom {
             selected_mode: None,
             dimensions: vec![],
             encode: None,
+            tooltip: None,
             data: vec![],
         }
     }
@@ -180,6 +185,11 @@ impl Custom {
 
     pub fn encode<E: Into<DimensionEncode>>(mut self, encode: E) -> Self {
         self.encode = Some(encode.into());
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/effect_scatter.rs
+++ b/charming/src/series/effect_scatter.rs
@@ -4,7 +4,7 @@ use crate::{
     datatype::{DataFrame, DataPoint},
     element::{
         Color, ColorBy, CoordinateSystem, Emphasis, ItemStyle, Label, LabelLayout, LabelLine,
-        Symbol,
+        Symbol, Tooltip,
     },
 };
 
@@ -162,6 +162,9 @@ pub struct EffectScatter {
     #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }
@@ -198,6 +201,7 @@ impl EffectScatter {
             label_layout: None,
             item_style: None,
             emphasis: None,
+            tooltip: None,
             data: vec![],
         }
     }
@@ -309,6 +313,11 @@ impl EffectScatter {
 
     pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
         self.emphasis = Some(emphasis.into());
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/funnel.rs
+++ b/charming/src/series/funnel.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     datatype::{CompositeValue, DataFrame, DataPoint},
-    element::{ColorBy, Emphasis, ItemStyle, Label, LabelLine, Orient, Sort},
+    element::{ColorBy, Emphasis, ItemStyle, Label, LabelLine, Orient, Sort, Tooltip},
 };
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
@@ -85,6 +85,9 @@ pub struct Funnel {
     #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }
@@ -121,6 +124,7 @@ impl Funnel {
             label_line: None,
             item_style: None,
             emphasis: None,
+            tooltip: None,
             data: vec![],
         }
     }
@@ -232,6 +236,11 @@ impl Funnel {
 
     pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
         self.emphasis = Some(emphasis.into());
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/gauge.rs
+++ b/charming/src/series/gauge.rs
@@ -4,7 +4,7 @@ use crate::{
     datatype::{DataFrame, DataPoint},
     element::{
         Anchor, AxisLabel, AxisLine, AxisTick, Color, ColorBy, Formatter, ItemStyle, Pointer,
-        SplitLine,
+        SplitLine, Tooltip,
     },
 };
 
@@ -287,6 +287,9 @@ pub struct Gauge {
     #[serde(skip_serializing_if = "Option::is_none")]
     title: Option<GaugeTitle>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }
@@ -324,6 +327,7 @@ impl Gauge {
             anchor: None,
             detail: None,
             title: None,
+            tooltip: None,
             data: vec![],
         }
     }
@@ -440,6 +444,11 @@ impl Gauge {
 
     pub fn title<T: Into<GaugeTitle>>(mut self, title: T) -> Self {
         self.title = Some(title.into());
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/graph.rs
+++ b/charming/src/series/graph.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::element::{CoordinateSystem, Label, LabelLayout, LineStyle, ScaleLimit};
+use crate::element::{CoordinateSystem, Label, LabelLayout, LineStyle, ScaleLimit, Tooltip};
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -275,6 +275,9 @@ pub struct Graph {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     edge_symbol: Option<(String, String)>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
 }
 
 impl Default for Graph {
@@ -308,6 +311,7 @@ impl Graph {
             links: vec![],
             data: vec![],
             edge_symbol: None,
+            tooltip: None,
         }
     }
 
@@ -405,6 +409,11 @@ impl Graph {
 
     pub fn edge_symbol(mut self, edge_symbol: Option<(String, String)>) -> Self {
         self.edge_symbol = edge_symbol;
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 }

--- a/charming/src/series/heatmap.rs
+++ b/charming/src/series/heatmap.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     datatype::DataFrame,
-    element::{CoordinateSystem, Emphasis, ItemStyle, Label},
+    element::{CoordinateSystem, Emphasis, ItemStyle, Label, Tooltip},
 };
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
@@ -59,6 +59,9 @@ pub struct Heatmap {
     #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<DataFrame>,
 }
@@ -89,6 +92,7 @@ impl Heatmap {
             label: None,
             item_style: None,
             emphasis: None,
+            tooltip: None,
             data: vec![],
         }
     }
@@ -170,6 +174,11 @@ impl Heatmap {
 
     pub fn emphasis(mut self, emphasis: Emphasis) -> Self {
         self.emphasis = Some(emphasis);
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/line.rs
+++ b/charming/src/series/line.rs
@@ -4,7 +4,7 @@ use crate::{
     datatype::{DataFrame, DataPoint},
     element::{
         smoothness::Smoothness, AreaStyle, CoordinateSystem, DimensionEncode, Emphasis, ItemStyle,
-        Label, LineStyle, MarkArea, MarkLine, MarkPoint, Symbol, SymbolSize,
+        Label, LineStyle, MarkArea, MarkLine, MarkPoint, Symbol, SymbolSize, Tooltip,
     },
 };
 
@@ -77,6 +77,9 @@ pub struct Line {
     #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_index: Option<f64>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }
@@ -112,6 +115,7 @@ impl Line {
             encode: None,
             x_axis_index: None,
             y_axis_index: None,
+            tooltip: None,
             data: vec![],
         }
     }
@@ -220,6 +224,11 @@ impl Line {
 
     pub fn y_axis_index<F: Into<f64>>(mut self, y_axis_index: F) -> Self {
         self.y_axis_index = Some(y_axis_index.into());
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/lines.rs
+++ b/charming/src/series/lines.rs
@@ -2,7 +2,9 @@
 
 use serde::Serialize;
 
-use crate::element::{ColorBy, CoordinateSystem, Emphasis, Label, LabelLayout, LineStyle, Symbol};
+use crate::element::{
+    ColorBy, CoordinateSystem, Emphasis, Label, LabelLayout, LineStyle, Symbol, Tooltip,
+};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -57,4 +59,7 @@ pub struct Lines {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
 }

--- a/charming/src/series/pie.rs
+++ b/charming/src/series/pie.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     datatype::{CompositeValue, DataFrame, DataPoint},
-    element::{ColorBy, CoordinateSystem, Emphasis, ItemStyle, Label, LabelLine},
+    element::{ColorBy, CoordinateSystem, Emphasis, ItemStyle, Label, LabelLine, Tooltip},
 };
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
@@ -75,6 +75,9 @@ pub struct Pie {
     #[serde(skip_serializing_if = "Option::is_none")]
     radius: Option<CompositeValue>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }
@@ -108,6 +111,7 @@ impl Pie {
             emphasis: None,
             center: None,
             radius: None,
+            tooltip: None,
             data: vec![],
         }
     }
@@ -204,6 +208,11 @@ impl Pie {
 
     pub fn radius<C: Into<CompositeValue>>(mut self, radius: C) -> Self {
         self.radius = Some(radius.into());
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/sankey.rs
+++ b/charming/src/series/sankey.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
-    element::{Emphasis, ItemStyle, Label, LineStyle, Orient},
+    element::{Emphasis, ItemStyle, Label, LineStyle, Orient, Tooltip},
 };
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
@@ -149,6 +149,9 @@ pub struct Sankey {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     links: Vec<SankeyLink>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<SankeyNode>,
 }
@@ -180,6 +183,7 @@ impl Sankey {
             node_align: None,
             line_style: None,
             links: vec![],
+            tooltip: None,
             data: vec![],
         }
     }
@@ -261,6 +265,11 @@ impl Sankey {
 
     pub fn line_style<L: Into<LineStyle>>(mut self, line_style: L) -> Self {
         self.line_style = Some(line_style.into());
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/sunburst.rs
+++ b/charming/src/series/sunburst.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::element::{Emphasis, ItemStyle, Label, Sort};
+use crate::element::{Emphasis, ItemStyle, Label, Sort, Tooltip};
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -150,6 +150,9 @@ pub struct Sunburst {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     levels: Vec<SunburstLevel>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<SunburstNode>,
 }
@@ -173,6 +176,7 @@ impl Sunburst {
             emphasis: None,
             sort: None,
             levels: vec![],
+            tooltip: None,
             data: vec![],
         }
     }
@@ -219,6 +223,11 @@ impl Sunburst {
 
     pub fn levels(mut self, levels: Vec<SunburstLevel>) -> Self {
         self.levels = levels;
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/theme_river.rs
+++ b/charming/src/series/theme_river.rs
@@ -2,7 +2,7 @@ use serde::{ser::SerializeSeq, Serialize};
 
 use crate::{
     datatype::CompositeValue,
-    element::{BoundaryGap, ColorBy, CoordinateSystem, Label},
+    element::{BoundaryGap, ColorBy, CoordinateSystem, Label, Tooltip},
 };
 
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
@@ -90,6 +90,9 @@ pub struct ThemeRiver {
     #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<ThemeRiverData>,
 }
@@ -116,6 +119,7 @@ impl ThemeRiver {
             coordinate_system: None,
             boundary_gap: None,
             label: None,
+            tooltip: None,
             data: vec![],
         }
     }
@@ -177,6 +181,11 @@ impl ThemeRiver {
 
     pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
         self.label = Some(label.into());
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/tree.rs
+++ b/charming/src/series/tree.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
-    element::{Blur, Emphasis, ItemStyle, Label, Select, Symbol},
+    element::{Blur, Emphasis, ItemStyle, Label, Select, Symbol, Tooltip},
 };
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
@@ -180,6 +180,9 @@ pub struct Tree {
     #[serde(skip_serializing_if = "Option::is_none")]
     leaves: Option<TreeLeaves>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<TreeNode>,
 }
@@ -227,6 +230,7 @@ impl Tree {
             animation_duration: None,
             animation_duration_update: None,
             leaves: None,
+            tooltip: None,
             data: vec![],
         }
     }
@@ -393,6 +397,11 @@ impl Tree {
 
     pub fn leaves<T: Into<TreeLeaves>>(mut self, leaves: T) -> Self {
         self.leaves = Some(leaves.into());
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/treemap.rs
+++ b/charming/src/series/treemap.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     datatype::CompositeValue,
-    element::{Emphasis, ItemStyle, Label},
+    element::{Emphasis, ItemStyle, Label, Tooltip},
 };
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
@@ -49,6 +49,9 @@ pub struct Treemap {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tooltip: Option<Tooltip>,
 }
 
 impl Default for Treemap {
@@ -74,6 +77,7 @@ impl Treemap {
             label: None,
             item_style: None,
             emphasis: None,
+            tooltip: None,
         }
     }
 
@@ -139,6 +143,11 @@ impl Treemap {
 
     pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
         self.emphasis = Some(emphasis.into());
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
+        self.tooltip = Some(tooltip);
         self
     }
 }


### PR DESCRIPTION
1. The MarkLine requires a `precision` configuration. According to the ECharts documentation at [this link](https://echarts.apache.org/zh/option.html#series-line.markLine.precision), the default value for precision is 2. If a higher precision is needed for plotting, it is currently not achievable. (Amend: add [silent](https://echarts.apache.org/zh/option.html#series-line.markLine.silent) field.)
2. Most series allow for custom `tooltips`, but currently, this functionality is missing. I have added the missing parts based on the ECharts documentation, which allows different series to customize their respective tooltip display content. As it stands, tooltips can only be defined globally at the Chart root.