### PR TITLE
Add missing field to boxplot

### DIFF
--- a/charming/src/series/boxplot.rs
+++ b/charming/src/series/boxplot.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::element::{ColorBy, CoordinateSystem, Tooltip};
+use crate::element::{ColorBy, CoordinateSystem, ItemStyle, Tooltip};
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -31,6 +31,15 @@ pub struct Boxplot {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    item_style: Option<ItemStyle>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    z: Option<usize>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Vec<Vec<f64>>>,
 }
 
 impl Default for Boxplot {
@@ -51,6 +60,9 @@ impl Boxplot {
             hover_animation: None,
             dataset_index: None,
             tooltip: None,
+            data: None,
+            item_style: None,
+            z: None,
         }
     }
 
@@ -91,6 +103,21 @@ impl Boxplot {
 
     pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
         self.tooltip = Some(tooltip);
+        self
+    }
+
+    pub fn item_style(mut self, item_style: ItemStyle) -> Self {
+        self.item_style = Some(item_style);
+        self
+    }
+
+    pub fn data(mut self, data: Vec<Vec<f64>>) -> Self {
+        self.data = Some(data);
+        self
+    }
+
+    pub fn z(mut self, z: usize) -> Self {
+        self.z = Some(z);
         self
     }
 }

--- a/charming/src/series/boxplot.rs
+++ b/charming/src/series/boxplot.rs
@@ -1,6 +1,9 @@
 use serde::Serialize;
 
-use crate::element::{ColorBy, CoordinateSystem, ItemStyle, Tooltip};
+use crate::{
+    datatype::{DataFrame, DataPoint},
+    element::{ColorBy, CoordinateSystem, ItemStyle, Tooltip},
+};
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -38,8 +41,8 @@ pub struct Boxplot {
     #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<usize>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    data: Option<Vec<Vec<f64>>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    data: DataFrame,
 }
 
 impl Default for Boxplot {
@@ -60,7 +63,7 @@ impl Boxplot {
             hover_animation: None,
             dataset_index: None,
             tooltip: None,
-            data: None,
+            data: vec![],
             item_style: None,
             z: None,
         }
@@ -106,13 +109,13 @@ impl Boxplot {
         self
     }
 
-    pub fn item_style(mut self, item_style: ItemStyle) -> Self {
-        self.item_style = Some(item_style);
+    pub fn item_style<S: Into<ItemStyle>>(mut self, item_style: S) -> Self {
+        self.item_style = Some(item_style.into());
         self
     }
 
-    pub fn data(mut self, data: Vec<Vec<f64>>) -> Self {
-        self.data = Some(data);
+    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
+        self.data = data.into_iter().map(|d| d.into()).collect();
         self
     }
 

--- a/gallery/src/boxplot/basic_boxplot.rs
+++ b/gallery/src/boxplot/basic_boxplot.rs
@@ -1,0 +1,66 @@
+use charming::{
+    component::{Axis, Grid, Title},
+    datatype::{DataFrame, DataPoint, DataPointItem},
+    element::{
+        AxisPointer, AxisPointerType, AxisType, ItemStyle, SplitArea, SplitLine, TextStyle,
+        Tooltip, Trigger,
+    },
+    series::{Boxplot, Scatter},
+    Chart,
+};
+
+pub fn chart() -> Chart {
+    let data: DataFrame = vec![
+        vec![655, 850, 940, 980, 1175].into(),
+        vec![672.5, 800.0, 845.0, 885.0, 1012.5].into(),
+        vec![780, 840, 855, 880, 940].into(),
+        vec![621.25, 767.5, 815.0, 865.0, 1011.25].into(),
+        DataPoint::Item(
+            DataPointItem::new(vec![713.75, 807.5, 830.0, 870.0, 963.75])
+                .item_style(ItemStyle::new().border_color("red")),
+        ),
+    ];
+    let outlier = vec![vec![2, 960], vec![2, 980], vec![2, 750], vec![4, 980]];
+    Chart::new()
+        .title(
+            Title::new()
+                .text("Michelson-Morley Experiment")
+                .left("center"),
+        )
+        .title(
+            Title::new()
+                .text("upper: Q3 + 1.5 * IQR \nlower: Q1 - 1.5 * IQR")
+                .border_color("#999")
+                .border_width(1)
+                .text_style(
+                    TextStyle::new()
+                        .font_weight("normal")
+                        .font_size(14)
+                        .line_height(20),
+                )
+                .left("10%")
+                .top("90%"),
+        )
+        .tooltip(
+            Tooltip::new()
+                .trigger(Trigger::Item)
+                .axis_pointer(AxisPointer::new().type_(AxisPointerType::Shadow)),
+        )
+        .grid(Grid::new().left("10%").right("10%").bottom("15%"))
+        .x_axis(
+            Axis::new()
+                .type_(AxisType::Category)
+                .boundary_gap(true)
+                .name_gap(30)
+                .split_area(SplitArea::new().show(false))
+                .split_line(SplitLine::new().show(false)),
+        )
+        .y_axis(
+            Axis::new()
+                .type_(AxisType::Value)
+                .name("km/s minus 299,000")
+                .split_area(SplitArea::new().show(true)),
+        )
+        .series(Boxplot::new().name("boxplot").data(data))
+        .series(Scatter::new().name("outlier").data(outlier))
+}

--- a/gallery/src/boxplot/mod.rs
+++ b/gallery/src/boxplot/mod.rs
@@ -1,3 +1,4 @@
+pub mod basic_boxplot;
 pub mod boxplot_light_velocity;
 pub mod boxplot_light_velocity2;
 pub mod data_transform_simple_aggregate;

--- a/gallery/src/lib.rs
+++ b/gallery/src/lib.rs
@@ -58,6 +58,7 @@ lazy_static! {
     };
     static ref BOXPLOT_CHARTS: BTreeMap<&'static str, fn() -> Chart> = {
         let mut m = BTreeMap::new();
+        insert!(m, boxplot, basic_boxplot);
         insert!(m, boxplot, boxplot_light_velocity);
         insert!(m, boxplot, boxplot_light_velocity2);
         insert!(m, boxplot, data_transform_simple_aggregate);


### PR DESCRIPTION
I have added some content to the BoxPlot based on the ECharts documentation. Currently, the BoxPlot can set data using the Dataset method, but this requires using ECharts' standard algorithm for box plots and inputting the raw data. If our programs have already calculated the box plot results, such as lower_whisker, q1, q2, q3, upper_whisker, and outliers, there is currently no way to set the data directly.