### PR TITLE
Added custom font setting

### DIFF
--- a/charming/src/component/radar_coordinate.rs
+++ b/charming/src/component/radar_coordinate.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use crate::{
     datatype::CompositeValue,
     element::{
+        font_settings::{FontFamily, FontStyle, FontWeight},
         AxisLabel, AxisLine, AxisTick, Color, Formatter, Padding, Shape, SplitArea, SplitLine,
     },
 };
@@ -23,13 +24,13 @@ pub struct RadarAxisName {
     color: Option<Color>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    font_style: Option<String>,
+    font_style: Option<FontStyle>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    font_weight: Option<String>,
+    font_weight: Option<FontWeight>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    font_family: Option<String>,
+    font_family: Option<FontFamily>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     font_size: Option<f64>,
@@ -161,17 +162,17 @@ impl RadarAxisName {
         self
     }
 
-    pub fn font_style<S: Into<String>>(mut self, font_style: S) -> Self {
+    pub fn font_style<F: Into<FontStyle>>(mut self, font_style: F) -> Self {
         self.font_style = Some(font_style.into());
         self
     }
 
-    pub fn font_weight<S: Into<String>>(mut self, font_weight: S) -> Self {
+    pub fn font_weight<F: Into<FontWeight>>(mut self, font_weight: F) -> Self {
         self.font_weight = Some(font_weight.into());
         self
     }
 
-    pub fn font_family<S: Into<String>>(mut self, font_family: S) -> Self {
+    pub fn font_family<F: Into<FontFamily>>(mut self, font_family: F) -> Self {
         self.font_family = Some(font_family.into());
         self
     }

--- a/charming/src/element/axis_label.rs
+++ b/charming/src/element/axis_label.rs
@@ -1,6 +1,10 @@
 use serde::Serialize;
 
-use super::{color::Color, Formatter};
+use super::{
+    color::Color,
+    font_settings::{FontFamily, FontStyle, FontWeight},
+    Formatter,
+};
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -10,6 +14,15 @@ pub struct AxisLabel {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     distance: Option<f64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    font_style: Option<FontStyle>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    font_weight: Option<FontWeight>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    font_family: Option<FontFamily>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     font_size: Option<f64>,
@@ -38,6 +51,9 @@ impl AxisLabel {
         Self {
             show: None,
             distance: None,
+            font_style: None,
+            font_weight: None,
+            font_family: None,
             font_size: None,
             color: None,
             formatter: None,
@@ -53,6 +69,21 @@ impl AxisLabel {
 
     pub fn distance<F: Into<f64>>(mut self, distance: F) -> Self {
         self.distance = Some(distance.into());
+        self
+    }
+
+    pub fn font_style<F: Into<FontStyle>>(mut self, font_style: F) -> Self {
+        self.font_style = Some(font_style.into());
+        self
+    }
+
+    pub fn font_weight<F: Into<FontWeight>>(mut self, font_weight: F) -> Self {
+        self.font_weight = Some(font_weight.into());
+        self
+    }
+
+    pub fn font_family<F: Into<FontFamily>>(mut self, font_family: F) -> Self {
+        self.font_family = Some(font_family.into());
         self
     }
 

--- a/charming/src/element/font_settings.rs
+++ b/charming/src/element/font_settings.rs
@@ -1,0 +1,139 @@
+use serde::Serialize;
+
+#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde(rename_all = "camelCase")]
+pub enum FontStyle {
+    Normal,
+    Italic,
+    Oblique,
+}
+
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
+pub enum FontWeight {
+    Normal,
+    Bold,
+    Bolder,
+    Lighter,
+    Number(i32),
+    Custom(String),
+}
+impl<S> From<S> for FontWeight
+where
+    S: Into<String>,
+{
+    fn from(s: S) -> Self {
+        let s = s.into();
+        match s.as_str() {
+            "normal" => FontWeight::Normal,
+            "bold" => FontWeight::Bold,
+            "bolder" => FontWeight::Bolder,
+            "lighter" => FontWeight::Lighter,
+            _ => FontWeight::Custom(s),
+        }
+    }
+}
+
+impl Serialize for FontWeight {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            FontWeight::Normal => serializer.serialize_str("normal"),
+            FontWeight::Bold => serializer.serialize_str("bold"),
+            FontWeight::Bolder => serializer.serialize_str("bolder"),
+            FontWeight::Lighter => serializer.serialize_str("lighter"),
+            FontWeight::Number(num) => serializer.serialize_i32(*num),
+            FontWeight::Custom(val) => serializer.serialize_str(val),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
+pub enum FontFamily {
+    Serif,
+    SansSerif,
+    MonoSpace,
+    Cursive,
+    Fantasy,
+    Custom(String),
+}
+
+impl<S> From<S> for FontFamily
+where
+    S: Into<String>,
+{
+    fn from(s: S) -> Self {
+        let s = s.into();
+        match s.as_str() {
+            "serif" => FontFamily::Serif,
+            "sans-serif" => FontFamily::SansSerif,
+            "monospace" => FontFamily::MonoSpace,
+            "cursive" => FontFamily::Cursive,
+            "fantasy" => FontFamily::Fantasy,
+            _ => FontFamily::Custom(s),
+        }
+    }
+}
+
+impl Serialize for FontFamily {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            FontFamily::Serif => serializer.serialize_str("serif"),
+            FontFamily::SansSerif => serializer.serialize_str("sans-serif"),
+            FontFamily::MonoSpace => serializer.serialize_str("monospace"),
+            FontFamily::Cursive => serializer.serialize_str("cursive"),
+            FontFamily::Fantasy => serializer.serialize_str("fantasy"),
+            FontFamily::Custom(val) => serializer.serialize_str(val),
+        }
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn font_style() {
+    let normal = serde_json::to_string(&FontStyle::Normal).unwrap();
+    let italic = serde_json::to_string(&FontStyle::Italic).unwrap();
+    let oblique = serde_json::to_string(&FontStyle::Oblique).unwrap();
+
+    assert_eq!("\"normal\"", normal);
+    assert_eq!("\"italic\"", italic);
+    assert_eq!("\"oblique\"", oblique);
+}
+
+#[test]
+fn font_weight() {
+    let normal = serde_json::to_string(&FontWeight::Normal).unwrap();
+    let bold = serde_json::to_string(&FontWeight::Bold).unwrap();
+    let bolder = serde_json::to_string(&FontWeight::Bolder).unwrap();
+    let lighter = serde_json::to_string(&FontWeight::Lighter).unwrap();
+    let number = serde_json::to_string(&FontWeight::Number(100)).unwrap();
+    let custom = serde_json::to_string(&FontWeight::Custom("test".to_string())).unwrap();
+
+    assert_eq!("\"normal\"", normal);
+    assert_eq!("\"bold\"", bold);
+    assert_eq!("\"bolder\"", bolder);
+    assert_eq!("\"lighter\"", lighter);
+    assert_eq!("100", number);
+    assert_eq!("\"test\"", custom);
+}
+
+#[test]
+fn font_family() {
+    let serif = serde_json::to_string(&FontFamily::Serif).unwrap();
+    let sans_serif = serde_json::to_string(&FontFamily::SansSerif).unwrap();
+    let monospace = serde_json::to_string(&FontFamily::MonoSpace).unwrap();
+    let cursive = serde_json::to_string(&FontFamily::Cursive).unwrap();
+    let fantasy = serde_json::to_string(&FontFamily::Fantasy).unwrap();
+    let custom = serde_json::to_string(&FontFamily::Custom("test".to_string())).unwrap();
+
+    assert_eq!("\"serif\"", serif);
+    assert_eq!("\"sans-serif\"", sans_serif);
+    assert_eq!("\"monospace\"", monospace);
+    assert_eq!("\"cursive\"", cursive);
+    assert_eq!("\"fantasy\"", fantasy);
+    assert_eq!("\"test\"", custom);
+}

--- a/charming/src/element/label.rs
+++ b/charming/src/element/label.rs
@@ -1,6 +1,11 @@
 use serde::Serialize;
 
-use super::{color::Color, line_style::LineStyle, Formatter};
+use super::{
+    color::Color,
+    font_settings::{FontFamily, FontStyle, FontWeight},
+    line_style::LineStyle,
+    Formatter,
+};
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -65,10 +70,16 @@ pub struct Label {
     color: Option<Color>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    font_size: Option<f64>,
+    font_style: Option<FontStyle>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    font_weight: Option<String>,
+    font_weight: Option<FontWeight>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    font_family: Option<FontFamily>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    font_size: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     padding: Option<(f64, f64, f64, f64)>,
@@ -117,8 +128,10 @@ impl Label {
             offset: None,
             formatter: None,
             color: None,
-            font_size: None,
+            font_style: None,
             font_weight: None,
+            font_family: None,
+            font_size: None,
             padding: None,
             align: None,
             vertical_align: None,
@@ -167,13 +180,23 @@ impl Label {
         self
     }
 
-    pub fn font_size<F: Into<f64>>(mut self, font_size: F) -> Self {
-        self.font_size = Some(font_size.into());
+    pub fn font_style<F: Into<FontStyle>>(mut self, font_style: F) -> Self {
+        self.font_style = Some(font_style.into());
         self
     }
 
-    pub fn font_weight<S: Into<String>>(mut self, font_weight: S) -> Self {
+    pub fn font_weight<F: Into<FontWeight>>(mut self, font_weight: F) -> Self {
         self.font_weight = Some(font_weight.into());
+        self
+    }
+
+    pub fn font_family<F: Into<FontFamily>>(mut self, font_family: F) -> Self {
+        self.font_family = Some(font_family.into());
+        self
+    }
+
+    pub fn font_size<F: Into<f64>>(mut self, font_size: F) -> Self {
+        self.font_size = Some(font_size.into());
         self
     }
 

--- a/charming/src/element/mod.rs
+++ b/charming/src/element/mod.rs
@@ -17,6 +17,7 @@ pub mod coordinate_tooltip;
 pub mod cursor;
 pub mod dimension_encode;
 pub mod emphasis;
+pub mod font_settings;
 pub mod formatter;
 pub mod icon;
 pub mod item_style;

--- a/charming/src/element/text_style.rs
+++ b/charming/src/element/text_style.rs
@@ -1,6 +1,9 @@
 use serde::Serialize;
 
-use super::color::Color;
+use super::{
+    color::Color,
+    font_settings::{FontFamily, FontStyle, FontWeight},
+};
 
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -9,13 +12,13 @@ pub struct TextStyle {
     color: Option<Color>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    font_style: Option<String>,
+    font_style: Option<FontStyle>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    font_weight: Option<String>,
+    font_weight: Option<FontWeight>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    font_family: Option<String>,
+    font_family: Option<FontFamily>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     font_size: Option<f64>,
@@ -55,17 +58,17 @@ impl TextStyle {
         self
     }
 
-    pub fn font_style<S: Into<String>>(mut self, font_style: S) -> Self {
+    pub fn font_style<F: Into<FontStyle>>(mut self, font_style: F) -> Self {
         self.font_style = Some(font_style.into());
         self
     }
 
-    pub fn font_weight<S: Into<String>>(mut self, font_weight: S) -> Self {
+    pub fn font_weight<F: Into<FontWeight>>(mut self, font_weight: F) -> Self {
         self.font_weight = Some(font_weight.into());
         self
     }
 
-    pub fn font_family<S: Into<String>>(mut self, font_family: S) -> Self {
+    pub fn font_family<F: Into<FontFamily>>(mut self, font_family: F) -> Self {
         self.font_family = Some(font_family.into());
         self
     }

--- a/charming/src/series/gauge.rs
+++ b/charming/src/series/gauge.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{
+        font_settings::{FontFamily, FontStyle, FontWeight},
         Anchor, AxisLabel, AxisLine, AxisTick, Color, ColorBy, Formatter, ItemStyle, Pointer,
         SplitLine, Tooltip,
     },
@@ -18,13 +19,13 @@ pub struct GaugeDetail {
     color: Option<Color>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    font_style: Option<String>,
+    font_style: Option<FontStyle>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    font_weight: Option<String>,
+    font_weight: Option<FontWeight>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    font_family: Option<String>,
+    font_family: Option<FontFamily>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     font_size: Option<f64>,
@@ -70,17 +71,17 @@ impl GaugeDetail {
         self
     }
 
-    pub fn font_style<S: Into<String>>(mut self, font_style: S) -> Self {
+    pub fn font_style<F: Into<FontStyle>>(mut self, font_style: F) -> Self {
         self.font_style = Some(font_style.into());
         self
     }
 
-    pub fn font_weight<S: Into<String>>(mut self, font_weight: S) -> Self {
+    pub fn font_weight<F: Into<FontWeight>>(mut self, font_weight: F) -> Self {
         self.font_weight = Some(font_weight.into());
         self
     }
 
-    pub fn font_family<S: Into<String>>(mut self, font_family: S) -> Self {
+    pub fn font_family<F: Into<FontFamily>>(mut self, font_family: F) -> Self {
         self.font_family = Some(font_family.into());
         self
     }

--- a/charming/src/series/graph.rs
+++ b/charming/src/series/graph.rs
@@ -122,6 +122,7 @@ pub struct GraphNodeLabel {
     #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<String>,
 
+    //TODO: I think this should be f64, would be a breaking change
     #[serde(skip_serializing_if = "Option::is_none")]
     font_size: Option<u64>,
 }

--- a/gallery/src/boxplot/basic_boxplot.rs
+++ b/gallery/src/boxplot/basic_boxplot.rs
@@ -2,8 +2,8 @@ use charming::{
     component::{Axis, Grid, Title},
     datatype::{DataFrame, DataPoint, DataPointItem},
     element::{
-        AxisPointer, AxisPointerType, AxisType, ItemStyle, SplitArea, SplitLine, TextStyle,
-        Tooltip, Trigger,
+        font_settings::FontWeight, AxisPointer, AxisPointerType, AxisType, ItemStyle, SplitArea,
+        SplitLine, TextStyle, Tooltip, Trigger,
     },
     series::{Boxplot, Scatter},
     Chart,
@@ -34,7 +34,7 @@ pub fn chart() -> Chart {
                 .border_width(1)
                 .text_style(
                     TextStyle::new()
-                        .font_weight("normal")
+                        .font_weight(FontWeight::Normal)
                         .font_size(14)
                         .line_height(20),
                 )

--- a/gallery/src/boxplot/boxplot_light_velocity.rs
+++ b/gallery/src/boxplot/boxplot_light_velocity.rs
@@ -2,7 +2,8 @@ use charming::{
     component::{Axis, Grid, Title},
     datatype::{Dataset, Transform},
     element::{
-        AxisPointer, AxisPointerType, AxisType, SplitArea, SplitLine, TextStyle, Tooltip, Trigger,
+        font_settings::FontWeight, AxisPointer, AxisPointerType, AxisType, SplitArea, SplitLine,
+        TextStyle, Tooltip, Trigger,
     },
     series::{Boxplot, Scatter},
     Chart,
@@ -54,7 +55,7 @@ pub fn chart() -> Chart {
                 .border_width(1)
                 .text_style(
                     TextStyle::new()
-                        .font_weight("normal")
+                        .font_weight(FontWeight::Normal)
                         .font_size(14)
                         .line_height(20),
                 )

--- a/gallery/src/pie/doughnut_chart_with_rounded_corner.rs
+++ b/gallery/src/pie/doughnut_chart_with_rounded_corner.rs
@@ -1,6 +1,8 @@
 use charming::{
     component::Legend,
-    element::{Emphasis, Label, LabelLine, LabelPosition, Tooltip, Trigger},
+    element::{
+        font_settings::FontWeight, Emphasis, Label, LabelLine, LabelPosition, Tooltip, Trigger,
+    },
     series::Pie,
     Chart,
 };
@@ -16,8 +18,12 @@ pub fn chart() -> Chart {
                 .avoid_label_overlap(false)
                 .label(Label::new().show(false).position(LabelPosition::Center))
                 .emphasis(
-                    Emphasis::new()
-                        .label(Label::new().show(true).font_size(40).font_weight("bold")),
+                    Emphasis::new().label(
+                        Label::new()
+                            .show(true)
+                            .font_size(40)
+                            .font_weight(FontWeight::Bold),
+                    ),
                 )
                 .label_line(LabelLine::new().show(false))
                 .data(vec![


### PR DESCRIPTION
Added enums for custom font settings.

- FontStyle
- FontWeight
- FontFamily

These were either not available or just settable as a String. This PR will add type safety to these settings where they were previously available and add them to new places like AxisLabel (fixes #111 ).

These won't be breaking changes as the types implement `From<Into<String>>` and old configurations are getting converted.

The last commit switches the gallery examples to the new types.