### PR TITLE
Deserialize chart

### DIFF
--- a/charming/src/component/angle_axis.rs
+++ b/charming/src/component/angle_axis.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::element::{
     AxisLabel, AxisLine, AxisPointer, AxisTick, AxisType, BoundaryGap, MinorSplitLine, MinorTick,
@@ -6,7 +6,7 @@ use crate::element::{
 };
 
 /// The angle axis in Polar Coordinate.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AngleAxis {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -101,6 +101,7 @@ pub struct AngleAxis {
     #[serde(skip_serializing_if = "Option::is_none")]
     split_area: Option<SplitArea>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<String>,
 }

--- a/charming/src/component/aria.rs
+++ b/charming/src/component/aria.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
@@ -8,7 +8,7 @@ use crate::{
 /**
 A single decal pattern.
  */
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DecalItem {
     /// The symbol type of the decal.
@@ -132,7 +132,7 @@ impl DecalItem {
 /**
 Decal patterns to be applied to series data.
  */
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Decal {
     /// Whether to show decal patterns. If `decals` is not set, this option is
@@ -143,6 +143,7 @@ pub struct Decal {
     /// The style of decal patterns. If multiple items are set, then each item
     /// in the array will have one style and the data will be looped through
     /// the array in order.
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     decals: Vec<DecalItem>,
 }
@@ -202,7 +203,7 @@ Chart::new()
     .series(Bar::new().data(vec![140, 230, 120, 50, 30, 150, 120]));
 ```
  */
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Aria {
     /// Whether to enable WAI-ARIA.

--- a/charming/src/component/axis.rs
+++ b/charming/src/component/axis.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Axis in cartesian coordinate.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Axis {
     /// Type of axis.
@@ -125,6 +125,7 @@ pub struct Axis {
     #[serde(skip_serializing_if = "Option::is_none")]
     split_line: Option<SplitLine>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<String>,
 }

--- a/charming/src/component/axis3d.rs
+++ b/charming/src/component/axis3d.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::element::AxisType;
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Axis3D {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/data_zoom.rs
+++ b/charming/src/component/data_zoom.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
     element::{Color, DataBackground, Orient, TextStyle},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
 pub enum FilterMode {
     Filter,
@@ -14,7 +14,7 @@ pub enum FilterMode {
     None,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum DataZoomType {
     Inside,
@@ -25,7 +25,7 @@ pub enum DataZoomType {
 /// DataZoom component is used for zooming a specific area, which enables user
 /// to investigate data in detail, or get an overview of the data, or get rid
 /// of outlier points.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataZoom {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/geo_map.rs
+++ b/charming/src/component/geo_map.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum GeoMapOpt {
     #[serde(rename = "geoJSON")]
     GeoJson {
@@ -20,7 +20,7 @@ where
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GeoMap {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/grid.rs
+++ b/charming/src/component/grid.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
     element::{Color, Padding, TextStyle, Trigger},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GridTooltip {
     /// Whether to show the tooltip component.
@@ -133,7 +133,7 @@ impl GridTooltip {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Grid {
     /// Component ID.

--- a/charming/src/component/grid3d.rs
+++ b/charming/src/component/grid3d.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Grid3D {}
 

--- a/charming/src/component/legend.rs
+++ b/charming/src/component/legend.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
     element::{Color, Icon, ItemStyle, LabelAlign, LineStyle, Orient, Padding, TextStyle},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum LegendType {
     /// Simple legend.
@@ -17,7 +17,7 @@ pub enum LegendType {
     Scroll,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum LegendSelectedMode {
     /// Multiple selection.
@@ -27,7 +27,7 @@ pub enum LegendSelectedMode {
     Single,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LegendItem {
     pub name: String,
@@ -69,7 +69,7 @@ impl From<(String, String)> for LegendItem {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Legend {
     /// Type of legend.
@@ -172,6 +172,7 @@ pub struct Legend {
     #[serde(skip_serializing_if = "Option::is_none")]
     inactive_color: Option<Color>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<LegendItem>,
 }

--- a/charming/src/component/parallel_axis.rs
+++ b/charming/src/component/parallel_axis.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::element::{AxisType, NameLocation};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ParallelAxis {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -39,6 +39,7 @@ pub struct ParallelAxis {
     #[serde(skip_serializing_if = "Option::is_none")]
     start_value: Option<f64>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<String>,
 }

--- a/charming/src/component/parallel_coordinate.rs
+++ b/charming/src/component/parallel_coordinate.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ParallelAxisDefault {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -78,6 +78,7 @@ pub struct ParallelAxisDefault {
     #[serde(skip_serializing_if = "Option::is_none")]
     split_line: Option<SplitLine>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<String>,
 }
@@ -233,7 +234,7 @@ impl ParallelAxisDefault {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ParallelCoordinate {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/polar_coordinate.rs
+++ b/charming/src/component/polar_coordinate.rs
@@ -1,9 +1,9 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::datatype::CompositeValue;
 
 /// Polar coordinate can be used in scatter and line chart.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PolarCoordinate {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/radar_coordinate.rs
+++ b/charming/src/component/radar_coordinate.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Name options for radar indicators.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadarAxisName {
     /// Whether to display the indicator's name.
@@ -298,7 +298,7 @@ impl RadarAxisName {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadarIndicator {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -373,7 +373,7 @@ impl From<(&str, i64, i64)> for RadarIndicator {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadarCoordinate {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -426,6 +426,7 @@ pub struct RadarCoordinate {
     #[serde(skip_serializing_if = "Option::is_none")]
     split_area: Option<SplitArea>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     indicator: Vec<RadarIndicator>,
 }

--- a/charming/src/component/radius_axis.rs
+++ b/charming/src/component/radius_axis.rs
@@ -1,9 +1,9 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::element::{AxisLabel, AxisLine, AxisType, BoundaryGap, NameLocation, TextStyle};
 
 /// Radius axis in polar coordinate.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadiusAxis {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -69,6 +69,7 @@ pub struct RadiusAxis {
     #[serde(skip_serializing_if = "Option::is_none")]
     axis_line: Option<AxisLine>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<String>,
 }

--- a/charming/src/component/single_axis.rs
+++ b/charming/src/component/single_axis.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{datatype::CompositeValue, element::Orient};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum Type {
     Value,
@@ -11,7 +11,7 @@ pub enum Type {
     Log,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SingleAxis {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/title.rs
+++ b/charming/src/component/title.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// Title component, including main title and subtitle.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Title {
     /// Component ID.

--- a/charming/src/component/toolbox.rs
+++ b/charming/src/component/toolbox.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{datatype::CompositeValue, element::Orient};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum SaveAsImageType {
     Png,
@@ -10,7 +10,7 @@ pub enum SaveAsImageType {
     Svg,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SaveAsImage {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -64,7 +64,7 @@ impl SaveAsImage {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Restore {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -99,7 +99,7 @@ impl Restore {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataView {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -143,7 +143,7 @@ impl DataView {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum MagicTypeType {
     /// For line charts.
@@ -165,7 +165,7 @@ impl From<&str> for MagicTypeType {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MagicType {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -200,7 +200,7 @@ impl MagicType {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
 pub enum BrushType {
     Rect,
@@ -211,9 +211,10 @@ pub enum BrushType {
     Clear,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Brush {
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     type_: Vec<BrushType>,
 }
@@ -235,7 +236,7 @@ impl Brush {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolboxDataZoom {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -259,7 +260,7 @@ impl ToolboxDataZoom {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Feature {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -330,7 +331,7 @@ impl Feature {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Toolbox {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/visual_map.rs
+++ b/charming/src/component/visual_map.rs
@@ -1,18 +1,18 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
     element::{Color, Orient, TextStyle},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum VisualMapType {
     Continuous,
     Piecewise,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VisualMapPiece {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -125,9 +125,10 @@ impl From<(i64, i64, &str)> for VisualMapPiece {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VisualMapChannel {
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     color: Vec<Color>,
 }
@@ -149,13 +150,14 @@ impl VisualMapChannel {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VisualMap {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     type_: Option<VisualMapType>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     color: Vec<Color>,
 
@@ -174,6 +176,7 @@ pub struct VisualMap {
     #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<f64>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     categories: Vec<String>,
 

--- a/charming/src/datatype/datapoint.rs
+++ b/charming/src/datatype/datapoint.rs
@@ -1,12 +1,12 @@
 use std::fmt::Debug;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::element::ItemStyle;
 
 use super::CompositeValue;
 
-#[derive(Serialize, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataPointItem {
     value: CompositeValue,
@@ -72,7 +72,7 @@ where
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum DataPoint {

--- a/charming/src/datatype/dimension.rs
+++ b/charming/src/datatype/dimension.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(untagged)]
 pub enum DimensionType {
     Number,
@@ -23,7 +23,7 @@ impl From<&str> for DimensionType {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Dimension {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/datatype/source.rs
+++ b/charming/src/datatype/source.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::CompositeValue;
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DataSource {
     Integers(Vec<Vec<i64>>),

--- a/charming/src/element/anchor.rs
+++ b/charming/src/element/anchor.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{icon::Icon, item_style::ItemStyle};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Anchor {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/area_style.rs
+++ b/charming/src/element/area_style.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::color::Color;
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum OriginPosition {
     Auto,
@@ -10,7 +10,7 @@ pub enum OriginPosition {
     End,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AreaStyle {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/axis_label.rs
+++ b/charming/src/element/axis_label.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{
     color::Color,
@@ -6,7 +6,7 @@ use super::{
     Formatter,
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisLabel {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/axis_pointer.rs
+++ b/charming/src/element/axis_pointer.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
     element::{Label, LineStyle},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum AxisPointerType {
     Line,
@@ -14,7 +14,7 @@ pub enum AxisPointerType {
     None,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum AxisPointerAxis {
     X,
@@ -23,7 +23,7 @@ pub enum AxisPointerAxis {
     Angle,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisPointerLink {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -78,7 +78,7 @@ impl AxisPointerLink {
 
 /// Axis Pointer is a tool for displaying reference line and axis value under
 /// mouse pointer.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisPointer {
     /// Component ID.
@@ -115,6 +115,7 @@ pub struct AxisPointer {
     line_style: Option<LineStyle>,
 
     /// Axis pointer can be linked to each other.
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     link: Vec<AxisPointerLink>,
 }

--- a/charming/src/element/axis_tick.rs
+++ b/charming/src/element/axis_tick.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::line_style::LineStyle;
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisTick {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/axis_type.rs
+++ b/charming/src/element/axis_type.rs
@@ -1,7 +1,7 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Type of axis.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum AxisType {
     /// Numerical axis, suitable for continuous data.

--- a/charming/src/element/background.rs
+++ b/charming/src/element/background.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{area_style::AreaStyle, border_type::BorderType, color::Color, line_style::LineStyle};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BackgroundStyle {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -73,7 +73,7 @@ impl BackgroundStyle {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataBackground {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/blur.rs
+++ b/charming/src/element/blur.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{item_style::ItemStyle, label::Label};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Blur {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/color.rs
+++ b/charming/src/element/color.rs
@@ -1,7 +1,7 @@
 use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum ColorBy {
     Series,

--- a/charming/src/element/coordinate.rs
+++ b/charming/src/element/coordinate.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum CoordinateSystem {
     Cartesian2d,

--- a/charming/src/element/cursor.rs
+++ b/charming/src/element/cursor.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum Cursor {
     Pointer,

--- a/charming/src/element/dimension_encode.rs
+++ b/charming/src/element/dimension_encode.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::datatype::CompositeValue;
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DimensionEncode {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17,6 +17,7 @@ pub struct DimensionEncode {
     #[serde(skip_serializing_if = "Option::is_none")]
     item_name: Option<String>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tooltip: Vec<CompositeValue>,
 }

--- a/charming/src/element/emphasis.rs
+++ b/charming/src/element/emphasis.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{item_style::ItemStyle, AreaStyle, Label};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum EmphasisFocus {
     None,
@@ -15,7 +15,7 @@ pub enum EmphasisFocus {
     Adjacency,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Emphasis {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/formatter.rs
+++ b/charming/src/element/formatter.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::RawString;
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(untagged)]
 pub enum Formatter {
     String(String),

--- a/charming/src/element/icon.rs
+++ b/charming/src/element/icon.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum Icon {
@@ -26,6 +26,42 @@ impl Serialize for Icon {
             Icon::None => serializer.serialize_str("none"),
             Icon::Custom(s) => serializer.serialize_str(s),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for Icon {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct IconVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for IconVisitor {
+            type Value = Icon;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string representing an icon")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Icon, E>
+            where
+                E: serde::de::Error,
+            {
+                match value {
+                    "circle" => Ok(Icon::Circle),
+                    "rect" => Ok(Icon::Rect),
+                    "roundRect" => Ok(Icon::RoundRect),
+                    "triangle" => Ok(Icon::Triangle),
+                    "diamond" => Ok(Icon::Diamond),
+                    "pin" => Ok(Icon::Pin),
+                    "arrow" => Ok(Icon::Arrow),
+                    "none" => Ok(Icon::None),
+                    custom => Ok(Icon::Custom(custom.to_string())),
+                }
+            }
+        }
+
+        deserializer.deserialize_str(IconVisitor)
     }
 }
 

--- a/charming/src/element/label.rs
+++ b/charming/src/element/label.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{
     color::Color,
@@ -7,7 +7,7 @@ use super::{
     Formatter,
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
 pub enum LabelPosition {
     Top,
@@ -29,7 +29,7 @@ pub enum LabelPosition {
     Center,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum LabelAlign {
     Left,
@@ -37,7 +37,7 @@ pub enum LabelAlign {
     Right,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum LabelVerticalAlign {
     Top,
@@ -45,7 +45,7 @@ pub enum LabelVerticalAlign {
     Bottom,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Label {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -256,7 +256,7 @@ impl Label {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LabelLine {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -327,7 +327,7 @@ impl LabelLine {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LabelLayout {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/line_style.rs
+++ b/charming/src/element/line_style.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::color::Color;
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum LineStyleType {
     Solid,
@@ -10,7 +10,7 @@ pub enum LineStyleType {
     Dotted,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LineStyle {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/link_target.rs
+++ b/charming/src/element/link_target.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum LinkTarget {
     #[serde(rename = "self")]

--- a/charming/src/element/mark_area.rs
+++ b/charming/src/element/mark_area.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{blur::Blur, emphasis::Emphasis, item_style::ItemStyle, label::Label};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkAreaData {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -46,7 +46,7 @@ impl MarkAreaData {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkArea {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -64,6 +64,7 @@ pub struct MarkArea {
     #[serde(skip_serializing_if = "Option::is_none")]
     blur: Option<Blur>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<(MarkAreaData, MarkAreaData)>,
 }

--- a/charming/src/element/mark_point.rs
+++ b/charming/src/element/mark_point.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum MarkPointDataType {
     Min,
@@ -19,7 +19,7 @@ impl From<&str> for MarkPointDataType {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkPointData {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -88,9 +88,10 @@ impl From<(&str, &str)> for MarkPointData {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkPoint {
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<MarkPointData>,
 }

--- a/charming/src/element/minor_split_line.rs
+++ b/charming/src/element/minor_split_line.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::line_style::LineStyle;
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MinorSplitLine {
     show: Option<bool>,

--- a/charming/src/element/minor_tick.rs
+++ b/charming/src/element/minor_tick.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::line_style::LineStyle;
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MinorTick {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/name_location.rs
+++ b/charming/src/element/name_location.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum NameLocation {
     Start,

--- a/charming/src/element/orient.rs
+++ b/charming/src/element/orient.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum Orient {
     Horizontal,

--- a/charming/src/element/parallel_layout.rs
+++ b/charming/src/element/parallel_layout.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum ParallelLayout {
     Horizontal,

--- a/charming/src/element/pointer.rs
+++ b/charming/src/element/pointer.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{icon::Icon, item_style::ItemStyle};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Pointer {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/scale_limit.rs
+++ b/charming/src/element/scale_limit.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ScaleLimit {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/select.rs
+++ b/charming/src/element/select.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{item_style::ItemStyle, label::Label};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Select {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/shape.rs
+++ b/charming/src/element/shape.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum Shape {
     Polygon,

--- a/charming/src/element/smoothness.rs
+++ b/charming/src/element/smoothness.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Debug, Deserialize, PartialEq, PartialOrd, Clone, Copy)]
 pub enum Smoothness {
     Single(f64),
     Boolean(bool),

--- a/charming/src/element/sort.rs
+++ b/charming/src/element/sort.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Debug, Deserialize, PartialEq, PartialOrd, Clone, Copy)]
 pub enum Sort {
     Ascending,
     Descending,

--- a/charming/src/element/split_area.rs
+++ b/charming/src/element/split_area.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SplitArea {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/split_line.rs
+++ b/charming/src/element/split_line.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::line_style::LineStyle;
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SplitLine {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/symbol_size.rs
+++ b/charming/src/element/symbol_size.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::RawString;
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(untagged)]
 pub enum SymbolSize {
     Number(f64),

--- a/charming/src/element/text_align.rs
+++ b/charming/src/element/text_align.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum TextAlign {
     Auto,
@@ -9,7 +9,7 @@ pub enum TextAlign {
     Center,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum TextVerticalAlign {
     Auto,

--- a/charming/src/element/text_style.rs
+++ b/charming/src/element/text_style.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{
     color::Color,
     font_settings::{FontFamily, FontStyle, FontWeight},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TextStyle {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/tooltip.rs
+++ b/charming/src/element/tooltip.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::element::{AxisPointer, Color, Formatter, Padding};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum TriggerOn {
     Mousemove,
@@ -13,7 +13,7 @@ pub enum TriggerOn {
 }
 
 /// Types of triggering.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum Trigger {
     Item,
@@ -21,7 +21,7 @@ pub enum Trigger {
     None,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Tooltip {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/lib.rs
+++ b/charming/src/lib.rs
@@ -99,7 +99,7 @@ use component::{
 };
 use datatype::Dataset;
 use element::{process_raw_strings, AxisPointer, Color, MarkLine, Tooltip};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_with::{formats::PreferOne, serde_as, OneOrMany};
 use series::Series;
 /**
@@ -237,9 +237,10 @@ mouse pointer.
 zoom, restore, and reset.
  */
 #[serde_as]
-#[derive(Serialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Chart {
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     title: Vec<Title>,
 
@@ -252,54 +253,69 @@ pub struct Chart {
     #[serde(skip_serializing_if = "Option::is_none")]
     toolbox: Option<Toolbox>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     grid: Vec<Grid>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "grid3D")]
     grid3d: Vec<Grid3D>,
 
+    #[serde(default)]
     #[serde_as(as = "OneOrMany<_, PreferOne>")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     x_axis: Vec<Axis>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "xAxis3D")]
     x_axis3d: Vec<Axis3D>,
 
+    #[serde(default)]
     #[serde_as(as = "OneOrMany<_, PreferOne>")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     y_axis: Vec<Axis>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "yAxis3D")]
     y_axis3d: Vec<Axis3D>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "zAxis3D")]
     z_axis3d: Vec<Axis3D>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     polar: Vec<PolarCoordinate>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     angle_axis: Vec<AngleAxis>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     radius_axis: Vec<RadiusAxis>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     single_axis: Option<SingleAxis>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     parallel_axis: Vec<ParallelAxis>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     axis_pointer: Vec<AxisPointer>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     visual_map: Vec<VisualMap>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data_zoom: Vec<DataZoom>,
 
@@ -309,9 +325,11 @@ pub struct Chart {
     #[serde(skip_serializing_if = "Option::is_none")]
     dataset: Option<Dataset>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     radar: Vec<RadarCoordinate>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     color: Vec<Color>,
 
@@ -324,9 +342,11 @@ pub struct Chart {
     #[serde(skip_serializing_if = "Option::is_none")]
     aria: Option<Aria>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     series: Vec<Series>,
 
+    #[serde(default)]
     #[serde(skip_serializing)]
     geo_maps: Vec<GeoMap>,
 }

--- a/charming/src/series/bar.rs
+++ b/charming/src/series/bar.rs
@@ -1,6 +1,6 @@
 use std::vec;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{DataFrame, DataPoint},
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Bar {
     #[serde(rename = "type")]
@@ -72,6 +72,7 @@ pub struct Bar {
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }

--- a/charming/src/series/bar3d.rs
+++ b/charming/src/series/bar3d.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{CompositeValue, DataFrame, DataPoint},
     element::{CoordinateSystem, DimensionEncode},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 pub struct Bar3d {
     #[serde(rename = "type")]
     type_: String,
@@ -31,6 +31,7 @@ pub struct Bar3d {
     #[serde(skip_serializing_if = "Option::is_none")]
     encode: Option<DimensionEncode>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }

--- a/charming/src/series/boxplot.rs
+++ b/charming/src/series/boxplot.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{ColorBy, CoordinateSystem, ItemStyle, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Boxplot {
     #[serde(rename = "type")]
@@ -41,6 +41,7 @@ pub struct Boxplot {
     #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<usize>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }

--- a/charming/src/series/candlestick.rs
+++ b/charming/src/series/candlestick.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{ColorBy, CoordinateSystem, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Candlestick {
     #[serde(rename = "type")]
@@ -29,6 +29,7 @@ pub struct Candlestick {
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }

--- a/charming/src/series/custom.rs
+++ b/charming/src/series/custom.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{CompositeValue, DataFrame, DataPoint, Dimension},
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Custom {
     type_: String,
@@ -58,6 +58,7 @@ pub struct Custom {
     #[serde(skip_serializing_if = "Option::is_none")]
     selected_mode: Option<bool>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     dimensions: Vec<Dimension>,
 
@@ -67,6 +68,7 @@ pub struct Custom {
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }

--- a/charming/src/series/effect_scatter.rs
+++ b/charming/src/series/effect_scatter.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{DataFrame, DataPoint},
@@ -8,27 +8,27 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum EffectType {
     Ripple,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum ShowEffectOn {
     Render,
     Emphasis,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum RippleEffectBrushType {
     Fill,
     Stroke,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RippleEffect {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -90,7 +90,7 @@ impl RippleEffect {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EffectScatter {
     #[serde(rename = "type")]
@@ -165,6 +165,7 @@ pub struct EffectScatter {
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }

--- a/charming/src/series/funnel.rs
+++ b/charming/src/series/funnel.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{CompositeValue, DataFrame, DataPoint},
     element::{ColorBy, Emphasis, ItemStyle, Label, LabelLine, Orient, Sort, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum Align {
     Left,
@@ -13,7 +13,7 @@ pub enum Align {
     Center,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Funnel {
     #[serde(rename = "type")]
@@ -88,6 +88,7 @@ pub struct Funnel {
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }

--- a/charming/src/series/gauge.rs
+++ b/charming/src/series/gauge.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{DataFrame, DataPoint},
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GaugeDetail {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -107,7 +107,7 @@ impl GaugeDetail {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GaugeTitle {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -142,7 +142,7 @@ impl GaugeTitle {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GaugeProgress {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -213,7 +213,7 @@ impl GaugeProgress {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Gauge {
     #[serde(rename = "type")]
@@ -291,6 +291,7 @@ pub struct Gauge {
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }

--- a/charming/src/series/graph.rs
+++ b/charming/src/series/graph.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::element::{CoordinateSystem, Label, LabelLayout, LineStyle, ScaleLimit, Tooltip};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphLayoutCircular {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -26,7 +26,7 @@ impl GraphLayoutCircular {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphLayoutForce {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -88,7 +88,7 @@ impl GraphLayoutForce {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum GraphLayout {
     None,
@@ -107,7 +107,7 @@ impl From<&str> for GraphLayout {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphNodeLabel {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -208,7 +208,7 @@ pub struct GraphData {
     pub categories: Vec<GraphCategory>,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Graph {
     #[serde(rename = "type")]
@@ -265,12 +265,15 @@ pub struct Graph {
     #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     categories: Vec<GraphCategory>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     links: Vec<GraphLink>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<GraphNode>,
 

--- a/charming/src/series/heatmap.rs
+++ b/charming/src/series/heatmap.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::DataFrame,
     element::{CoordinateSystem, Emphasis, ItemStyle, Label, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Heatmap {
     #[serde(rename = "type")]
@@ -62,6 +62,7 @@ pub struct Heatmap {
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<DataFrame>,
 }

--- a/charming/src/series/line.rs
+++ b/charming/src/series/line.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{DataFrame, DataPoint},
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Line {
     #[serde(rename = "type")]
@@ -80,6 +80,7 @@ pub struct Line {
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }

--- a/charming/src/series/map.rs
+++ b/charming/src/series/map.rs
@@ -1,5 +1,5 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Map {}

--- a/charming/src/series/mod.rs
+++ b/charming/src/series/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::large_enum_variant)]
 
-use serde::Serialize;
+use serde::{Deserialize, Deserializer, Serialize};
 
 pub mod bar;
 pub mod bar3d;
@@ -74,6 +74,49 @@ pub enum Series {
     ThemeRiver(theme_river::ThemeRiver),
     Tree(tree::Tree),
     Treemap(treemap::Treemap),
+}
+
+impl<'de> Deserialize<'de> for Series {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+
+        let result = match value.get("type").and_then(serde_json::Value::as_str) {
+            Some(type_) => match type_ {
+                "bar" => serde_json::from_value(value).map(Series::Bar),
+                "bar3d" => serde_json::from_value(value).map(Series::Bar3d),
+                "boxplot" => serde_json::from_value(value).map(Series::Boxplot),
+                "candlestick" => serde_json::from_value(value).map(Series::Candlestick),
+                "custom" => serde_json::from_value(value).map(Series::Custom),
+                "effectScatter" => serde_json::from_value(value).map(Series::EffectScatter),
+                "funnel" => serde_json::from_value(value).map(Series::Funnel),
+                "gauge" => serde_json::from_value(value).map(Series::Gauge),
+                "graph" => serde_json::from_value(value).map(Series::Graph),
+                "heatmap" => serde_json::from_value(value).map(Series::Heatmap),
+                "line" => serde_json::from_value(value).map(Series::Line),
+                "map" => serde_json::from_value(value).map(Series::Map),
+                "parallel" => serde_json::from_value(value).map(Series::Parallel),
+                "pictorialBar" => serde_json::from_value(value).map(Series::PictorialBar),
+                "pie" => serde_json::from_value(value).map(Series::Pie),
+                "radar" => serde_json::from_value(value).map(Series::Radar),
+                "sankey" => serde_json::from_value(value).map(Series::Sankey),
+                "scatter" => serde_json::from_value(value).map(Series::Scatter),
+                "sunburst" => serde_json::from_value(value).map(Series::Sunburst),
+                "themeRiver" => serde_json::from_value(value).map(Series::ThemeRiver),
+                "tree" => serde_json::from_value(value).map(Series::Tree),
+                "treemap" => serde_json::from_value(value).map(Series::Treemap),
+                unknown => Err(serde::de::Error::custom(format!(
+                    "unknown series type: {}",
+                    unknown
+                ))),
+            },
+            None => Err(serde::de::Error::custom("missing series type")),
+        };
+
+        Ok(result.map_err(serde::de::Error::custom)?)
+    }
 }
 
 macro_rules! impl_series {

--- a/charming/src/series/parallel.rs
+++ b/charming/src/series/parallel.rs
@@ -1,18 +1,18 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{smoothness::Smoothness, ColorBy, CoordinateSystem, Emphasis, LineStyle},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum ProgressiveChunkMode {
     Sequential,
     Mod,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Parallel {
     #[serde(rename = "type")]
@@ -60,6 +60,7 @@ pub struct Parallel {
     #[serde(skip_serializing_if = "Option::is_none")]
     progressive_chunk_mode: Option<ProgressiveChunkMode>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }

--- a/charming/src/series/pictorial_bar.rs
+++ b/charming/src/series/pictorial_bar.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::DataFrame,
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PictorialBar {
     #[serde(rename = "type")]
@@ -58,6 +58,7 @@ pub struct PictorialBar {
     #[serde(skip_serializing_if = "Option::is_none")]
     symbol_bounding_data: Option<f64>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<DataFrame>,
 }

--- a/charming/src/series/pie.rs
+++ b/charming/src/series/pie.rs
@@ -1,18 +1,18 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{CompositeValue, DataFrame, DataPoint},
     element::{ColorBy, CoordinateSystem, Emphasis, ItemStyle, Label, LabelLine, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum PieRoseType {
     Radius,
     Area,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Pie {
     #[serde(rename = "type")]
@@ -78,6 +78,7 @@ pub struct Pie {
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }

--- a/charming/src/series/radar.rs
+++ b/charming/src/series/radar.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{AreaStyle, ColorBy, Emphasis, LineStyle, Symbol, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Radar {
     #[serde(rename = "type")]
@@ -17,6 +17,7 @@ pub struct Radar {
     #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 

--- a/charming/src/series/sankey.rs
+++ b/charming/src/series/sankey.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{Emphasis, ItemStyle, Label, LineStyle, Orient, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum SankeyNodeAlign {
     Left,
@@ -92,7 +92,7 @@ where
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Sankey {
     #[serde(rename = "type")]
@@ -146,12 +146,14 @@ pub struct Sankey {
     #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     links: Vec<SankeyLink>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<SankeyNode>,
 }

--- a/charming/src/series/scatter.rs
+++ b/charming/src/series/scatter.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::{DataFrame, DataPoint},
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Scatter {
     #[serde(rename = "type")]
@@ -59,6 +59,7 @@ pub struct Scatter {
     #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: DataFrame,
 }

--- a/charming/src/series/sunburst.rs
+++ b/charming/src/series/sunburst.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::element::{Emphasis, ItemStyle, Label, Sort, Tooltip};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SunburstLevel {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -67,6 +67,7 @@ pub struct SunburstNode {
     #[serde(skip_deserializing)]
     item_style: Option<ItemStyle>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     children: Vec<SunburstNode>,
 }
@@ -117,7 +118,7 @@ impl From<(&str, f64, &str)> for SunburstNode {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Sunburst {
     #[serde(rename = "type")]
@@ -147,12 +148,14 @@ pub struct Sunburst {
     #[serde(skip_serializing_if = "Option::is_none")]
     sort: Option<Sort>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     levels: Vec<SunburstLevel>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<SunburstNode>,
 }

--- a/charming/src/series/tree.rs
+++ b/charming/src/series/tree.rs
@@ -5,14 +5,14 @@ use crate::{
     element::{Blur, Emphasis, ItemStyle, Label, Select, Symbol, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum TreeLayout {
     Orthogonal,
     Radial,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 pub enum TreeOrient {
     #[serde(rename = "LR")]
     LeftRight,
@@ -24,14 +24,14 @@ pub enum TreeOrient {
     BottomTop,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum TreeEdgeShape {
     Curve,
     Polyline,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TreeLeaves {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -71,7 +71,7 @@ pub struct TreeNode {
 }
 
 /// The tree diagram is mainly used to display the tree data structure.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Tree {
     #[serde(rename = "type")]
@@ -183,6 +183,7 @@ pub struct Tree {
     #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     data: Vec<TreeNode>,
 }

--- a/charming/src/series/treemap.rs
+++ b/charming/src/series/treemap.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     datatype::CompositeValue,
     element::{Emphasis, ItemStyle, Label, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Treemap {
     #[serde(rename = "type")]

--- a/charming/tests/deserialize.rs
+++ b/charming/tests/deserialize.rs
@@ -1,0 +1,43 @@
+#[cfg(test)]
+mod tests {
+    use charming::{
+        component::{Axis, Title},
+        element::AxisType,
+        series::Line,
+        Chart,
+    };
+
+    #[test]
+    fn test_deserialize_chart() {
+        let chart = Chart::new()
+            .title(Title::new().text("Demo: Yew + Charming"))
+            .x_axis(
+                Axis::new()
+                    .type_(AxisType::Category)
+                    .data(vec!["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]),
+            )
+            .y_axis(Axis::new().type_(AxisType::Value))
+            .series(Line::new().data(vec![150, 230, 224, 218, 135, 147, 260]));
+
+        let chart_str = serde_json::to_string(&chart).expect("Should be able to serialize chart");
+        let chart_deserialized =
+            serde_json::from_str(&chart_str).expect("Should be able to deserialize chart");
+
+        assert_eq!(
+            chart, chart_deserialized,
+            "Deserialized chart should be equal to original chart"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_chart_invalid_axis_category() {
+        let incomplete_json =
+            r#"{"title": [{"text": "Demo: Yew + Charming"}], "xAxis": {"type": "invalid"}}"#;
+        let result = serde_json::from_str::<Chart>(incomplete_json);
+
+        assert!(
+            result.is_err(),
+            "Expected an error for incomplete data, but deserialization succeeded"
+        );
+    }
+}


### PR DESCRIPTION
Adds `Deserialize` support to various data structures in order to support deserializing `Chart`, as well as a couple extremely basic test cases to test deserialization.

Most of this was straightforward, just adding `Deserialize` to the derive attribute. But the following have custom `Serialize` implementations, so I wrote custom `Deserialize` implementations to match:

-    datatype::Dataset
-    series::Series
-    series::ThemeRiverData
-    element::axis_line
-    element::BoundaryGap
-    element::FontFamily
-    element::Icon
-    element::MarkLineVariant
-    element::Padding
-    element::RawString
-    element::Symbol

The other change was some vectors have `skip_serializing_if = "Vec::is_empty"`, which was causing problem with deserialization since there wasn't anything to initialize these vectors. For all of those I set `#[serde(default)]` so that they can deserialize with empty vectors.

