### PR TITLE
Fix Wasm HashMap conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "deno_core",
  "handlebars",
  "image",
+ "js-sys",
  "resvg",
  "serde",
  "serde-wasm-bindgen",

--- a/charming/Cargo.toml
+++ b/charming/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = "1.0"
 serde_v8 = { version = "0.220", optional = true }
 serde_with = "3.11.0"
 wasm-bindgen = { version = "0.2", optional = true }
+js-sys = { version = "0.3", optional = true }
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"
@@ -39,7 +40,7 @@ features = [
 default = ["html"]
 html = ["handlebars"]
 ssr = ["html", "deno_core", "image", "resvg", "serde_v8"]
-wasm = ["serde-wasm-bindgen", "wasm-bindgen", "web-sys"]
+wasm = ["serde-wasm-bindgen", "wasm-bindgen", "web-sys", "js-sys"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/charming/src/renderer/wasm_renderer.rs
+++ b/charming/src/renderer/wasm_renderer.rs
@@ -3,7 +3,6 @@ use serde::Serialize;
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
-use web_sys::js_sys::JSON;
 
 pub struct WasmRenderer {
     theme: Theme,
@@ -68,7 +67,7 @@ impl WasmRenderer {
 
     pub fn update(echarts: &Echarts, chart: &Chart) {
         let json_str = serde_json::to_string(chart).unwrap();
-        let option = JSON::parse(&json_str).unwrap();
+        let option = js_sys::JSON::parse(&json_str).unwrap();
         echarts.set_option(option);
     }
 }

--- a/charming/src/renderer/wasm_renderer.rs
+++ b/charming/src/renderer/wasm_renderer.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
+use web_sys::js_sys::JSON;
 
 pub struct WasmRenderer {
     theme: Theme,
@@ -54,7 +55,7 @@ impl WasmRenderer {
             })
             .unwrap(),
         );
-        echarts.set_option(to_value(chart).unwrap());
+        Self::update(&echarts, chart);
 
         Ok(echarts)
     }
@@ -66,7 +67,9 @@ impl WasmRenderer {
     }
 
     pub fn update(echarts: &Echarts, chart: &Chart) {
-        echarts.set_option(to_value(chart).unwrap());
+        let json_str = serde_json::to_string(chart).unwrap();
+        let option = JSON::parse(&json_str).unwrap();
+        echarts.set_option(option);
     }
 }
 


### PR DESCRIPTION
We can set the selected state of legends using a HashMap:

```rust
    selected: Option<HashMap<String, bool>>,
```

This works fine using the HtmlRenderer, which sets the chart option using to_string:
```rust
        let data = Handlebars::new()
            .render_template(
                template,
                &serde_json::json!({
                    "title": self.title,
                    "theme": theme,
                    "theme_source": theme_source,
                    "width": self.width,
                    "height": self.height,
                    "chart_id": "chart",
                    "canvas_type": canvas_type,
                    "chart_option": chart.to_string(), // <- here
                }),
            )
```

But this param is currently not working using the WasmRenderer, because it uses ```to_value``` which converts the HashMap to a ```Map``` object which is not compatible with the echarts config.

I've replaced the ```to_value``` call with ```js_sys::JSON::parse``` which generates a compatible  option object.