### PR TITLE
Enable formatter in wasm (breaking)

### DIFF
--- a/charming/Cargo.toml
+++ b/charming/Cargo.toml
@@ -17,7 +17,7 @@ handlebars = { version = "4.3", optional = true }
 image = { version = "0.24", optional = true }
 resvg = { version = "0.36", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-serde-wasm-bindgen = {version = "0.6", optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
 serde_json = "1.0"
 serde_v8 = { version = "0.220", optional = true }
 serde_with = "3.11.0"
@@ -30,11 +30,7 @@ assert-json-diff = "2.0.2"
 [dependencies.web-sys]
 version = "0.3.64"
 optional = true
-features = [
-    "Window",
-    "Document",
-    "Element",
-]
+features = ["Window", "Document", "Element"]
 
 [features]
 default = ["html"]

--- a/charming/src/component/angle_axis.rs
+++ b/charming/src/component/angle_axis.rs
@@ -6,7 +6,7 @@ use crate::element::{
 };
 
 /// The angle axis in Polar Coordinate.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AngleAxis {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/aria.rs
+++ b/charming/src/component/aria.rs
@@ -202,7 +202,7 @@ Chart::new()
     .series(Bar::new().data(vec![140, 230, 120, 50, 30, 150, 120]));
 ```
  */
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Aria {
     /// Whether to enable WAI-ARIA.

--- a/charming/src/component/axis.rs
+++ b/charming/src/component/axis.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Axis in cartesian coordinate.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Axis {
     /// Type of axis.

--- a/charming/src/component/parallel_coordinate.rs
+++ b/charming/src/component/parallel_coordinate.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ParallelAxisDefault {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -233,7 +233,7 @@ impl ParallelAxisDefault {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ParallelCoordinate {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/radar_coordinate.rs
+++ b/charming/src/component/radar_coordinate.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Name options for radar indicators.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadarAxisName {
     /// Whether to display the indicator's name.
@@ -373,7 +373,7 @@ impl From<(&str, i64, i64)> for RadarIndicator {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadarCoordinate {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/component/radius_axis.rs
+++ b/charming/src/component/radius_axis.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use crate::element::{AxisLabel, AxisLine, AxisType, BoundaryGap, NameLocation, TextStyle};
 
 /// Radius axis in polar coordinate.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadiusAxis {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/axis_label.rs
+++ b/charming/src/element/axis_label.rs
@@ -6,7 +6,7 @@ use super::{
     Formatter,
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisLabel {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/axis_pointer.rs
+++ b/charming/src/element/axis_pointer.rs
@@ -78,7 +78,7 @@ impl AxisPointerLink {
 
 /// Axis Pointer is a tool for displaying reference line and axis value under
 /// mouse pointer.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisPointer {
     /// Component ID.

--- a/charming/src/element/blur.rs
+++ b/charming/src/element/blur.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::{item_style::ItemStyle, label::Label};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Blur {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/emphasis.rs
+++ b/charming/src/element/emphasis.rs
@@ -15,7 +15,7 @@ pub enum EmphasisFocus {
     Adjacency,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Emphasis {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/label.rs
+++ b/charming/src/element/label.rs
@@ -51,7 +51,7 @@ pub enum LabelVerticalAlign {
     Bottom,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Label {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/mark_area.rs
+++ b/charming/src/element/mark_area.rs
@@ -46,7 +46,7 @@ impl MarkAreaData {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkArea {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/mark_line.rs
+++ b/charming/src/element/mark_line.rs
@@ -25,7 +25,7 @@ impl From<&str> for MarkLineDataType {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkLineData {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -130,7 +130,7 @@ impl From<(&str, &str)> for MarkLineData {
     }
 }
 
-#[derive(Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum MarkLineVariant {
     Simple(MarkLineData),
@@ -151,7 +151,7 @@ impl Serialize for MarkLineVariant {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkLine {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/select.rs
+++ b/charming/src/element/select.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::{item_style::ItemStyle, label::Label};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Select {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/element/tooltip.rs
+++ b/charming/src/element/tooltip.rs
@@ -21,7 +21,7 @@ pub enum Trigger {
     None,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Tooltip {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/charming/src/renderer/wasm_renderer.rs
+++ b/charming/src/renderer/wasm_renderer.rs
@@ -1,4 +1,4 @@
-use crate::{theme::Theme, Chart, EchartsError};
+use crate::{element::process_raw_strings, theme::Theme, Chart, EchartsError};
 use serde::Serialize;
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::prelude::*;
@@ -66,9 +66,8 @@ impl WasmRenderer {
     }
 
     pub fn update(echarts: &Echarts, chart: &Chart) {
-        let json_str = serde_json::to_string(chart).unwrap();
-        let option = js_sys::JSON::parse(&json_str).unwrap();
-        echarts.set_option(option);
+        let js = serde_wasm_bindgen::to_value(&chart).unwrap();
+        echarts.set_option(js);
     }
 }
 

--- a/charming/src/renderer/wasm_renderer.rs
+++ b/charming/src/renderer/wasm_renderer.rs
@@ -1,4 +1,4 @@
-use crate::{element::process_raw_strings, theme::Theme, Chart, EchartsError};
+use crate::{theme::Theme, Chart, EchartsError};
 use serde::Serialize;
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::prelude::*;

--- a/charming/src/series/bar.rs
+++ b/charming/src/series/bar.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Bar {
     #[serde(rename = "type")]

--- a/charming/src/series/boxplot.rs
+++ b/charming/src/series/boxplot.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{ColorBy, CoordinateSystem, ItemStyle, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Boxplot {
     #[serde(rename = "type")]

--- a/charming/src/series/candlestick.rs
+++ b/charming/src/series/candlestick.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{ColorBy, CoordinateSystem, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Candlestick {
     #[serde(rename = "type")]

--- a/charming/src/series/custom.rs
+++ b/charming/src/series/custom.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Custom {
     type_: String,

--- a/charming/src/series/effect_scatter.rs
+++ b/charming/src/series/effect_scatter.rs
@@ -90,7 +90,7 @@ impl RippleEffect {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EffectScatter {
     #[serde(rename = "type")]

--- a/charming/src/series/funnel.rs
+++ b/charming/src/series/funnel.rs
@@ -13,7 +13,7 @@ pub enum Align {
     Center,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Funnel {
     #[serde(rename = "type")]

--- a/charming/src/series/gauge.rs
+++ b/charming/src/series/gauge.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GaugeDetail {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -213,7 +213,7 @@ impl GaugeProgress {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Gauge {
     #[serde(rename = "type")]

--- a/charming/src/series/graph.rs
+++ b/charming/src/series/graph.rs
@@ -208,7 +208,7 @@ pub struct GraphData {
     pub categories: Vec<GraphCategory>,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Graph {
     #[serde(rename = "type")]

--- a/charming/src/series/heatmap.rs
+++ b/charming/src/series/heatmap.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{CoordinateSystem, Emphasis, ItemStyle, Label, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Heatmap {
     #[serde(rename = "type")]

--- a/charming/src/series/line.rs
+++ b/charming/src/series/line.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Line {
     #[serde(rename = "type")]

--- a/charming/src/series/mod.rs
+++ b/charming/src/series/mod.rs
@@ -50,7 +50,7 @@ pub use theme_river::*;
 pub use tree::*;
 pub use treemap::*;
 
-#[derive(Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Series {
     Bar(bar::Bar),
     Bar3d(bar3d::Bar3d),

--- a/charming/src/series/parallel.rs
+++ b/charming/src/series/parallel.rs
@@ -12,7 +12,7 @@ pub enum ProgressiveChunkMode {
     Mod,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Parallel {
     #[serde(rename = "type")]

--- a/charming/src/series/pictorial_bar.rs
+++ b/charming/src/series/pictorial_bar.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PictorialBar {
     #[serde(rename = "type")]

--- a/charming/src/series/pie.rs
+++ b/charming/src/series/pie.rs
@@ -12,7 +12,7 @@ pub enum PieRoseType {
     Area,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Pie {
     #[serde(rename = "type")]

--- a/charming/src/series/radar.rs
+++ b/charming/src/series/radar.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{AreaStyle, ColorBy, Emphasis, LineStyle, Symbol, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Radar {
     #[serde(rename = "type")]

--- a/charming/src/series/sankey.rs
+++ b/charming/src/series/sankey.rs
@@ -92,7 +92,7 @@ where
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Sankey {
     #[serde(rename = "type")]

--- a/charming/src/series/scatter.rs
+++ b/charming/src/series/scatter.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Scatter {
     #[serde(rename = "type")]

--- a/charming/src/series/sunburst.rs
+++ b/charming/src/series/sunburst.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::element::{Emphasis, ItemStyle, Label, Sort, Tooltip};
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SunburstLevel {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -117,7 +117,7 @@ impl From<(&str, f64, &str)> for SunburstNode {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Sunburst {
     #[serde(rename = "type")]

--- a/charming/src/series/theme_river.rs
+++ b/charming/src/series/theme_river.rs
@@ -48,7 +48,7 @@ where
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ThemeRiver {
     #[serde(rename = "type")]

--- a/charming/src/series/tree.rs
+++ b/charming/src/series/tree.rs
@@ -31,7 +31,7 @@ pub enum TreeEdgeShape {
     Polyline,
 }
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TreeLeaves {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -71,7 +71,7 @@ pub struct TreeNode {
 }
 
 /// The tree diagram is mainly used to display the tree data structure.
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Tree {
     #[serde(rename = "type")]

--- a/charming/src/series/treemap.rs
+++ b/charming/src/series/treemap.rs
@@ -5,7 +5,7 @@ use crate::{
     element::{Emphasis, ItemStyle, Label, Tooltip},
 };
 
-#[derive(Serialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Treemap {
     #[serde(rename = "type")]

--- a/gallery/src/line/confidence_band.rs
+++ b/gallery/src/line/confidence_band.rs
@@ -1,8 +1,8 @@
 use charming::{
     component::{Axis, Grid, Title},
     element::{
-        AreaStyle, AxisLabel, AxisPointer, AxisPointerType, AxisType, Formatter, ItemStyle, Label,
-        LineStyle, Symbol, Tooltip, Trigger,
+        AreaStyle, AxisLabel, AxisPointer, AxisPointerType, AxisType, FormatterFunction, ItemStyle,
+        Label, LineStyle, Symbol, Tooltip, Trigger,
     },
     series::Line,
     Chart,
@@ -41,10 +41,8 @@ pub fn chart() -> Chart {
                     ),
                 )
                 .formatter(
-                    Formatter::Function(
-                        format!("function (params) {{ return (params[2].name + '<br />' + ((params[2].value - {}) * 100).toFixed(1) + '%'); }}", base
-                    ).into())
-                ),
+                    FormatterFunction::new_with_args("params", &format!("return (params[2].name + '<br />' + ((params[2].value - {}) * 100).toFixed(1) + '%');", base)),
+                )
         )
         .grid(Grid::new().left("3%").right("4%").bottom("3%").contain_label(true))
         .x_axis(
@@ -53,21 +51,19 @@ pub fn chart() -> Chart {
                 .data(data.iter().map(|x| x.date.clone()).collect())
                 .axis_label(
                     AxisLabel::new().formatter(
-                        Formatter::Function(
-                            "function (value, idx) { var date = new Date(value); return idx === 0 ? value : [date.getMonth() + 1, date.getDate()].join('-'); }".into())
-                        )
-                    )
+                        FormatterFunction::new_with_args("value, idx", "var date = new Date(value); return idx === 0 ? value : [date.getMonth() + 1, date.getDate()].join('-');")
+                    ))
                 .boundary_gap(false)
         )
         .y_axis(
             Axis::new()
                 .axis_label(AxisLabel::new().formatter(
-                    Formatter::Function(format!("function (val) {{ return (val - {}) * 100 + '%'; }}", base).into()))
+                    FormatterFunction::new_with_args("val", &format!("return (val - {}) * 100 + '%';", base)))
                 )
                 .axis_pointer(
                     AxisPointer::new().label(
                         Label::new().formatter(
-                            Formatter::Function(format!("function (params) {{ return ((params.value - {}) * 100).toFixed(1) + '%'; }}", base).into())
+                            FormatterFunction::new_with_args("params", &format!("return ((params.value - {}) * 100).toFixed(1) + '%';", base))
                         )
                     )
                 ).split_number(3)

--- a/gallery/src/line/distribution_of_electricity.rs
+++ b/gallery/src/line/distribution_of_electricity.rs
@@ -1,7 +1,7 @@
 use charming::{
     component::{Axis, Feature, SaveAsImage, Title, Toolbox, VisualMap, VisualMapPiece},
     element::{
-        AxisLabel, AxisPointer, AxisPointerType, AxisType, Formatter, ItemStyle, MarkArea,
+        AxisLabel, AxisPointer, AxisPointerType, AxisType, FormatterFunction, ItemStyle, MarkArea,
         MarkAreaData, Tooltip, Trigger,
     },
     series::Line,
@@ -19,7 +19,10 @@ pub fn chart() -> Chart {
             Tooltip::new()
                 .trigger(Trigger::Axis)
                 .axis_pointer(AxisPointer::new().type_(AxisPointerType::Cross))
-                .value_formatter(Formatter::Function("value => value + 'W'".into())),
+                .value_formatter(FormatterFunction::new_with_args(
+                    "value",
+                    "return String(value).concat('W');",
+                )),
         )
         .toolbox(
             Toolbox::new()

--- a/gallery/src/scatter/bubble_chart.rs
+++ b/gallery/src/scatter/bubble_chart.rs
@@ -2,8 +2,8 @@ use charming::{
     component::{Axis, Grid, Legend, Title},
     df,
     element::{
-        Color, ColorStop, Emphasis, EmphasisFocus, Formatter, ItemStyle, Label, LabelPosition,
-        LineStyle, LineStyleType, SplitLine,
+        Color, ColorStop, Emphasis, EmphasisFocus, FormatterFunction, ItemStyle, Label,
+        LabelPosition, LineStyle, LineStyleType, SplitLine,
     },
     series::Scatter,
     Chart,
@@ -94,8 +94,9 @@ pub fn chart() -> Chart {
                     Emphasis::new().focus(EmphasisFocus::Series).label(
                         Label::new()
                             .show(true)
-                            .formatter(Formatter::Function(
-                                "function (param) { return param.data[3]; }".into(),
+                            .formatter(FormatterFunction::new_with_args(
+                                "params",
+                                "return params.data[3];",
                             ))
                             .position(LabelPosition::Top),
                     ),
@@ -125,8 +126,9 @@ pub fn chart() -> Chart {
                     Emphasis::new().focus(EmphasisFocus::Series).label(
                         Label::new()
                             .show(true)
-                            .formatter(Formatter::Function(
-                                "function (param) { return param.data[3]; }".into(),
+                            .formatter(FormatterFunction::new_with_args(
+                                "params",
+                                "return params.data[3];",
                             ))
                             .position(LabelPosition::Top),
                     ),


### PR DESCRIPTION
Enables the use of formatter functions in wasm and non wasm environments with the same interface. This is a breaking change for custom formatters. For examples on how to use/migrate to the new formatter, please check the udpated examples: `confidence_band`, `distribution_of_electricity` and `bubble_chart`.

If someone wants to follow the changes, the commits are fairly well-structured.