### PR TITLE
Derive `Clone`/`Default`/`Eq` for `Theme`, and implement `TryFrom<&str>`.

### DIFF
--- a/charming/src/theme/mod.rs
+++ b/charming/src/theme/mod.rs
@@ -1,4 +1,4 @@
-#[derive(Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum Theme {
     #[default]
     Default,

--- a/charming/src/theme/mod.rs
+++ b/charming/src/theme/mod.rs
@@ -42,3 +42,27 @@ impl Theme {
         }
     }
 }
+
+impl TryFrom<&str> for Theme {
+    type Error = String;
+
+    fn try_from(name: &str) -> Result<Self, Self::Error> {
+        match name {
+            "" => Ok(Theme::Default),
+            "dark" => Ok(Theme::Dark),
+            "vintage" => Ok(Theme::Vintage),
+            "westeros" => Ok(Theme::Westeros),
+            "essos" => Ok(Theme::Essos),
+            "wonderland" => Ok(Theme::Wonderland),
+            "walden" => Ok(Theme::Walden),
+            "chalk" => Ok(Theme::Chalk),
+            "infographic" => Ok(Theme::Infographic),
+            "macarons" => Ok(Theme::Macarons),
+            "roma" => Ok(Theme::Roma),
+            "shine" => Ok(Theme::Shine),
+            "purple-passion" => Ok(Theme::PurplePassion),
+            "halloween" => Ok(Theme::Halloween),
+            _ => Err(format!("unrecognized theme {name:?}")),
+        }
+    }
+}


### PR DESCRIPTION
Hello, and thanks a lot for this great library!

This patch adds some "quality-of-life traits" to the `Theme` enum for library users:
* `Clone` is quite necessary as basically every function/struct which accepts a `Theme` as an argument takes ownership of it, making re-using a single `Theme` value for multiple `Charts` impossible (I've chosen `Clone` over `Copy` as the `Theme::Custom` contains some `&'static str`).
* `TryFrom<&str>`  is useful in a dynamic context, such as dynamically loading a theme from a CLI argument.
* `Debug` allows for deriving `Debug` in structs which will wrap/hold a `Theme`.
* `Eq` is somewhat extra but I think it's very likely for someone to find themselves wanting to compare themes at some point (either a library user or an internal library developer).