### PR TITLE
fix: leptos example code complaining about non reactivity

### DIFF
--- a/examples/leptos-demo/src/main.rs
+++ b/examples/leptos-demo/src/main.rs
@@ -8,37 +8,33 @@ use leptos::prelude::*;
 use leptos_use::use_interval_fn;
 use leptos_use::utils::Pausable;
 
+
 #[component]
 fn App() -> impl IntoView {
     let data = RwSignal::new(vec![150, 230, 224, 218, 135, 147, 260]);
-    let action = Action::new(move |_input: &()| {
-        let local = data.get();
-        async move {
-            let chart = Chart::new()
-                .title(Title::new().text("Demo: Leptos + Charming"))
-                .x_axis(
-                    Axis::new()
-                        .type_(AxisType::Category)
-                        .data(vec!["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]),
-                )
-                .y_axis(Axis::new().type_(AxisType::Value))
-                .series(Line::new().data(local));
 
-            let renderer = WasmRenderer::new(600, 400);
-            renderer.render("chart",&chart).unwrap();
-    }});
+    Effect::new(move |_| {
+        let local = data.get();
+
+        let chart = Chart::new()
+            .title(Title::new().text("Demo: Leptos + Charming"))
+            .x_axis(
+                Axis::new()
+                    .type_(AxisType::Category)
+                    .data(vec!["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]),
+            )
+            .y_axis(Axis::new().type_(AxisType::Value))
+            .series(Line::new().data(local));
+
+        let renderer = WasmRenderer::new(600, 400);
+        renderer.render("chart", &chart).unwrap();
+    });
 
     let Pausable { pause, resume, is_active: _ } = use_interval_fn(
         move || {
             data.update(|d| d.rotate_right(1));
-            action.dispatch(());
-        },
-        1000
+        }, 1000
     );
-    
-
-    action.dispatch(());
-
     view! {
         <div>
             <div id="chart"></div>


### PR DESCRIPTION
Hi ! 

![image](https://github.com/user-attachments/assets/5517f294-9344-4332-af52-e86612948bf3)

It looks like the leptos example was complaining about the lack of the reactivity
Effect is more proper than Action in leptos for this use case. 


Another fix could be to use the ```.get_untracked()```  and keep Action, but I felt that this fix was making a clearer and broader use-case for people willing to learn from that example