### PR TITLE
Add a derive macro to cut down on a lot of boilerplate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "charming_macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -2635,9 +2644,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,8 +486,11 @@ dependencies = [
 name = "charming_macros"
 version = "0.1.0"
 dependencies = [
+ "charming",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_with",
  "syn",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,7 @@ version = "0.5.1"
 dependencies = [
  "assert-json-diff",
  "charming-gallery",
+ "charming_macros",
  "deno_core",
  "handlebars",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["charming", "gallery"]
+members = ["charming", "charming_macros", "gallery"]
 exclude = [
   "examples/dioxus-web-demo",
   "examples/dioxus-desktop-demo",

--- a/charming/Cargo.toml
+++ b/charming/Cargo.toml
@@ -13,6 +13,7 @@ readme = "../README.md"
 rust-version = "1.85"
 
 [dependencies]
+charming_macros = { path = "../charming_macros", version = "0.1" }
 deno_core = { version = "0.348", optional = true }
 handlebars = { version = "6.0", optional = true }
 image = { version = "0.25", optional = true }
@@ -27,7 +28,7 @@ js-sys = { version = "0.3", optional = true }
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"
-charming-gallery = { path = "../gallery"}
+charming-gallery = { path = "../gallery" }
 resvg = "0.45"
 test_each_file = "0.3.5"
 

--- a/charming/src/component/angle_axis.rs
+++ b/charming/src/component/angle_axis.rs
@@ -1,294 +1,54 @@
-use serde::{Deserialize, Serialize};
-
 use crate::element::{
     AxisLabel, AxisLine, AxisPointer, AxisTick, AxisType, BoundaryGap, MinorSplitLine, MinorTick,
     SplitArea, SplitLine,
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 /// The angle axis in Polar Coordinate.
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AngleAxis {
-    #[serde(skip_serializing_if = "Option::is_none")]
     boundary_gap: Option<BoundaryGap>,
-
     /// Component ID.
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
     /// The index of angle axis in Polar Coordinate.
-    #[serde(skip_serializing_if = "Option::is_none")]
     polar_index: Option<f64>,
-
     /// Starting angle of axis, default to 90.
-    #[serde(skip_serializing_if = "Option::is_none")]
     start_angle: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     end_angle: Option<f64>,
-
     /// Whether the direction of axis is clockwise, default to true.
-    #[serde(skip_serializing_if = "Option::is_none")]
     clockwise: Option<bool>,
-
     /// Type of axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     type_: Option<AxisType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     zlevel: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
     /// The minimun value of axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     min: Option<f64>,
-
     /// The maximum value of axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     scale: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_number: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min_interval: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_interval: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     interval: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     log_base: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     start_value: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     silent: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     trigger_event: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_line: Option<AxisLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_tick: Option<AxisTick>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_pointer: Option<AxisPointer>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     minor_tick: Option<MinorTick>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_label: Option<AxisLabel>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_line: Option<SplitLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     minor_split_line: Option<MinorSplitLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_area: Option<SplitArea>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<String>,
-}
-
-impl Default for AngleAxis {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl AngleAxis {
-    pub fn new() -> Self {
-        Self {
-            boundary_gap: None,
-            id: None,
-            polar_index: None,
-            start_angle: None,
-            end_angle: None,
-            clockwise: None,
-            type_: None,
-            zlevel: None,
-            z: None,
-            min: None,
-            max: None,
-            scale: None,
-            split_number: None,
-            min_interval: None,
-            max_interval: None,
-            interval: None,
-            log_base: None,
-            start_value: None,
-            silent: None,
-            trigger_event: None,
-            axis_line: None,
-            axis_tick: None,
-            axis_pointer: None,
-            minor_tick: None,
-            axis_label: None,
-            split_line: None,
-            minor_split_line: None,
-            split_area: None,
-            data: vec![],
-        }
-    }
-
-    pub fn boundary_gap<B: Into<BoundaryGap>>(mut self, boundary_gap: B) -> Self {
-        self.boundary_gap = Some(boundary_gap.into());
-        self
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn polar_index<F: Into<f64>>(mut self, polar_index: F) -> Self {
-        self.polar_index = Some(polar_index.into());
-        self
-    }
-
-    pub fn start_angle<F: Into<f64>>(mut self, start_angle: F) -> Self {
-        self.start_angle = Some(start_angle.into());
-        self
-    }
-
-    pub fn end_angle<F: Into<f64>>(mut self, end_angle: F) -> Self {
-        self.end_angle = Some(end_angle.into());
-        self
-    }
-
-    pub fn clockwise(mut self, clockwise: bool) -> Self {
-        self.clockwise = Some(clockwise);
-        self
-    }
-
-    pub fn type_<T: Into<AxisType>>(mut self, type_: T) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
-
-    pub fn zlevel<F: Into<f64>>(mut self, zlevel: F) -> Self {
-        self.zlevel = Some(zlevel.into());
-        self
-    }
-
-    pub fn z<F: Into<f64>>(mut self, z: F) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
-    pub fn min<F: Into<f64>>(mut self, min: F) -> Self {
-        self.min = Some(min.into());
-        self
-    }
-
-    pub fn max<F: Into<f64>>(mut self, max: F) -> Self {
-        self.max = Some(max.into());
-        self
-    }
-
-    pub fn scale(mut self, scale: bool) -> Self {
-        self.scale = Some(scale);
-        self
-    }
-
-    pub fn split_number<F: Into<f64>>(mut self, split_number: F) -> Self {
-        self.split_number = Some(split_number.into());
-        self
-    }
-
-    pub fn min_interval<F: Into<f64>>(mut self, min_interval: F) -> Self {
-        self.min_interval = Some(min_interval.into());
-        self
-    }
-
-    pub fn max_interval<F: Into<f64>>(mut self, max_interval: F) -> Self {
-        self.max_interval = Some(max_interval.into());
-        self
-    }
-
-    pub fn interval<F: Into<f64>>(mut self, interval: F) -> Self {
-        self.interval = Some(interval.into());
-        self
-    }
-
-    pub fn log_base<F: Into<f64>>(mut self, log_base: F) -> Self {
-        self.log_base = Some(log_base.into());
-        self
-    }
-
-    pub fn start_value<F: Into<f64>>(mut self, start_value: F) -> Self {
-        self.start_value = Some(start_value.into());
-        self
-    }
-
-    pub fn silent(mut self, silent: bool) -> Self {
-        self.silent = Some(silent);
-        self
-    }
-
-    pub fn trigger_event(mut self, trigger_event: bool) -> Self {
-        self.trigger_event = Some(trigger_event);
-        self
-    }
-
-    pub fn axis_line<A: Into<AxisLine>>(mut self, axis_line: A) -> Self {
-        self.axis_line = Some(axis_line.into());
-        self
-    }
-
-    pub fn axis_tick<A: Into<AxisTick>>(mut self, axis_tick: A) -> Self {
-        self.axis_tick = Some(axis_tick.into());
-        self
-    }
-
-    pub fn axis_pointer<A: Into<AxisPointer>>(mut self, axis_pointer: A) -> Self {
-        self.axis_pointer = Some(axis_pointer.into());
-        self
-    }
-
-    pub fn minor_tick<M: Into<MinorTick>>(mut self, minor_tick: M) -> Self {
-        self.minor_tick = Some(minor_tick.into());
-        self
-    }
-
-    pub fn axis_label<A: Into<AxisLabel>>(mut self, axis_label: A) -> Self {
-        self.axis_label = Some(axis_label.into());
-        self
-    }
-
-    pub fn split_line<S: Into<SplitLine>>(mut self, split_line: S) -> Self {
-        self.split_line = Some(split_line.into());
-        self
-    }
-
-    pub fn minor_split_line<M: Into<MinorSplitLine>>(mut self, minor_split_line: M) -> Self {
-        self.minor_split_line = Some(minor_split_line.into());
-        self
-    }
-
-    pub fn split_area<S: Into<SplitArea>>(mut self, split_area: S) -> Self {
-        self.split_area = Some(split_area.into());
-        self
-    }
-
-    pub fn data<S: Into<String>>(mut self, data: Vec<S>) -> Self {
-        self.data = data.into_iter().map(|s| s.into()).collect();
-        self
-    }
 }

--- a/charming/src/component/aria.rs
+++ b/charming/src/component/aria.rs
@@ -1,176 +1,64 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{Color, Label, Symbol},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 /**
 A single decal pattern.
  */
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DecalItem {
     /// The symbol type of the decal.
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol: Option<Symbol>,
-
     /// The size of symbol relative to decal, ranging from 0 to 1.
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_size: Option<f64>,
-
     /// Whether to keep the aspect ratio of the pattern.
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_keep_aspect: Option<bool>,
-
     ///The color of the decal pattern. it is recommended to use a translucent
     /// color, which can be superimposed on the color of the series itself.
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-
     /// The background color of the decal will be over the color of the series
     /// itself, under the decal pattern.
-    #[serde(skip_serializing_if = "Option::is_none")]
     background_color: Option<Color>,
-
     /// Controls the horizontal pattern.
-    #[serde(skip_serializing_if = "Option::is_none")]
     dash_array_x: Option<CompositeValue>,
-
     /// Controls the vertical pattern.
-    #[serde(skip_serializing_if = "Option::is_none")]
     dash_array_y: Option<CompositeValue>,
-
     /// The overall rotation angle (in radians) of the pattern.
-    #[serde(skip_serializing_if = "Option::is_none")]
     rotation: Option<f64>,
-
     /// The upper limit of the width of the generated pattern before it is
     /// duplicated.
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_tile_width: Option<f64>,
-
     /// The upper limit of the height of the generated pattern before it is
     /// duplicated.
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_tile_height: Option<f64>,
-}
-
-impl Default for DecalItem {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DecalItem {
-    pub fn new() -> DecalItem {
-        DecalItem {
-            symbol: None,
-            symbol_size: None,
-            symbol_keep_aspect: None,
-            color: None,
-            background_color: None,
-            dash_array_x: None,
-            dash_array_y: None,
-            rotation: None,
-            max_tile_width: None,
-            max_tile_height: None,
-        }
-    }
-
-    pub fn symbol<S: Into<Symbol>>(mut self, symbol: S) -> DecalItem {
-        self.symbol = Some(symbol.into());
-        self
-    }
-
-    pub fn symbol_size<F: Into<f64>>(mut self, symbol_size: F) -> DecalItem {
-        self.symbol_size = Some(symbol_size.into());
-        self
-    }
-
-    pub fn symbol_keep_aspect(mut self, symbol_keep_aspect: bool) -> DecalItem {
-        self.symbol_keep_aspect = Some(symbol_keep_aspect);
-        self
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: C) -> DecalItem {
-        self.color = Some(color.into());
-        self
-    }
-
-    pub fn background_color<C: Into<Color>>(mut self, background_color: C) -> DecalItem {
-        self.background_color = Some(background_color.into());
-        self
-    }
-
-    pub fn dash_array_x<F: Into<CompositeValue>>(mut self, dash_array_x: F) -> DecalItem {
-        self.dash_array_x = Some(dash_array_x.into());
-        self
-    }
-
-    pub fn dash_array_y<F: Into<CompositeValue>>(mut self, dash_array_y: F) -> DecalItem {
-        self.dash_array_y = Some(dash_array_y.into());
-        self
-    }
-
-    pub fn rotation<F: Into<f64>>(mut self, rotation: F) -> DecalItem {
-        self.rotation = Some(rotation.into());
-        self
-    }
-
-    pub fn max_tile_width<F: Into<f64>>(mut self, max_tile_width: F) -> DecalItem {
-        self.max_tile_width = Some(max_tile_width.into());
-        self
-    }
-
-    pub fn max_tile_height<F: Into<f64>>(mut self, max_tile_height: F) -> DecalItem {
-        self.max_tile_height = Some(max_tile_height.into());
-        self
-    }
 }
 
 /**
 Decal patterns to be applied to series data.
  */
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
 pub struct Decal {
     /// Whether to show decal patterns. If `decals` is not set, this option is
     /// used to enable the default decal pattern.
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
     /// The style of decal patterns. If multiple items are set, then each item
     /// in the array will have one style and the data will be looped through
     /// the array in order.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     decals: Vec<DecalItem>,
-}
-
-impl Default for Decal {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Decal {
-    pub fn new() -> Decal {
-        Decal {
-            show: None,
-            decals: vec![],
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Decal {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn decals<D: Into<DecalItem>>(mut self, decals: Vec<D>) -> Decal {
-        self.decals = decals.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }
 
 /**
@@ -203,53 +91,21 @@ Chart::new()
     .series(Bar::new().data(vec![140, 230, 120, 50, 30, 150, 120]));
 ```
  */
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
 pub struct Aria {
     /// Whether to enable WAI-ARIA.
-    #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
-
     /// If `enabled` is set to `true`, `label` is enabled by default. When
     /// enabled, the description of the chart will be automatically and
     /// intelligently generated based on the chart, data title, etc. Users can
     /// also modify the description through `label`.
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
     /// Decal patterns are added to series data as an additional hint other
     /// than colors to help differentiate the data.
-    #[serde(skip_serializing_if = "Option::is_none")]
     decal: Option<Decal>,
-}
-
-impl Default for Aria {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Aria {
-    pub fn new() -> Aria {
-        Aria {
-            enabled: None,
-            label: None,
-            decal: None,
-        }
-    }
-
-    pub fn enabled(mut self, enabled: bool) -> Aria {
-        self.enabled = Some(enabled);
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Aria {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn decal<D: Into<Decal>>(mut self, decal: D) -> Aria {
-        self.decal = Some(decal.into());
-        self
-    }
 }

--- a/charming/src/component/axis.rs
+++ b/charming/src/component/axis.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{
@@ -7,338 +5,76 @@ use crate::{
         SplitLine, TextStyle,
     },
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 /// Axis in cartesian coordinate.
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Axis {
     /// Type of axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     type_: Option<AxisType>,
-
     /// Id of axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
     /// Whether to show the axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
     /// Index of grid which is used to place this axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     grid_index: Option<f64>,
-
     /// Offset of this axis relative to default position.
-    #[serde(skip_serializing_if = "Option::is_none")]
     offset: Option<f64>,
-
     /// Name of axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
     /// Location of axis name.
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_location: Option<NameLocation>,
-
     /// Text style of axis name.
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_text_style: Option<TextStyle>,
-
     /// Gap between axis name and axis line.
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_gap: Option<f64>,
-
     /// Rotation of axis name
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_rotation: Option<f64>,
-
     /// Set this to `true` to invert the axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     inverse: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     align_ticks: Option<bool>,
-
     /// The boundary gap on both sides of a coordinate axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     boundary_gap: Option<BoundaryGap>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     position: Option<CompositeValue>,
-
     /// The mimimum value of axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     min: Option<CompositeValue>,
-
     /// The maximum value of axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     scale: Option<bool>,
-
     /// Number of segments that the axis is split into.
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_number: Option<f64>,
-
     /// Minimum gap between split lines.
-    #[serde(skip_serializing_if = "Option::is_none")]
     min_interval: Option<f64>,
-
     /// Maximum gap between split lines.
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_interval: Option<f64>,
-
     /// Compulsively set segmentation interval for axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     interval: Option<f64>,
-
     /// Base of logarithm, which is valid only for numeric axes with `log` type.
-    #[serde(skip_serializing_if = "Option::is_none")]
     log_base: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     start_value: Option<f64>,
-
     /// Value of all graphical elements in x axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     z_level: Option<f64>,
-
     /// Value of all graphical elements in x axis, which controls order of drawing graphical components.
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
     /// Settings related to axis label.
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_label: Option<AxisLabel>,
-
     /// Settings related to axis tick.
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_tick: Option<AxisTick>,
-
     /// Settings related to axis line.
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_line: Option<AxisLine>,
-
     /// Settings related to axis pointer.
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_pointer: Option<AxisPointer>,
-
     /// Settings related to split area.
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_area: Option<SplitArea>,
-
     /// Settings related to split line.
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_line: Option<SplitLine>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<String>,
-}
-
-impl Default for Axis {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Axis {
-    pub fn new() -> Self {
-        Self {
-            type_: None,
-            id: None,
-            show: None,
-            grid_index: None,
-            offset: None,
-            name: None,
-            name_location: None,
-            name_text_style: None,
-            name_gap: None,
-            name_rotation: None,
-            inverse: None,
-            boundary_gap: None,
-            position: None,
-            min: None,
-            max: None,
-            scale: None,
-            split_number: None,
-            min_interval: None,
-            max_interval: None,
-            interval: None,
-            align_ticks: None,
-            log_base: None,
-            start_value: None,
-            z_level: None,
-            z: None,
-            axis_label: None,
-            axis_tick: None,
-            axis_line: None,
-            axis_pointer: None,
-            split_area: None,
-            split_line: None,
-            data: vec![],
-        }
-    }
-
-    pub fn type_<T: Into<AxisType>>(mut self, type_: T) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn grid_index<F: Into<f64>>(mut self, grid_index: F) -> Self {
-        self.grid_index = Some(grid_index.into());
-        self
-    }
-
-    pub fn offset<F: Into<f64>>(mut self, offset: F) -> Self {
-        self.offset = Some(offset.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn name_location<E: Into<NameLocation>>(mut self, name_location: E) -> Self {
-        self.name_location = Some(name_location.into());
-        self
-    }
-
-    pub fn name_text_style<T: Into<TextStyle>>(mut self, name_text_style: T) -> Self {
-        self.name_text_style = Some(name_text_style.into());
-        self
-    }
-
-    pub fn name_gap<F: Into<f64>>(mut self, name_gap: F) -> Self {
-        self.name_gap = Some(name_gap.into());
-        self
-    }
-
-    pub fn name_rotation<F: Into<f64>>(mut self, name_rotation: F) -> Self {
-        self.name_rotation = Some(name_rotation.into());
-        self
-    }
-
-    pub fn inverse(mut self, inverse: bool) -> Self {
-        self.inverse = Some(inverse);
-        self
-    }
-
-    pub fn align_ticks(mut self, align_ticks: bool) -> Self {
-        self.align_ticks = Some(align_ticks);
-        self
-    }
-
-    pub fn boundary_gap<B: Into<BoundaryGap>>(mut self, boundary_gap: B) -> Self {
-        self.boundary_gap = Some(boundary_gap.into());
-        self
-    }
-
-    pub fn position<C: Into<CompositeValue>>(mut self, position: C) -> Self {
-        self.position = Some(position.into());
-        self
-    }
-
-    pub fn min<C: Into<CompositeValue>>(mut self, min: C) -> Self {
-        self.min = Some(min.into());
-        self
-    }
-
-    pub fn max<C: Into<CompositeValue>>(mut self, max: C) -> Self {
-        self.max = Some(max.into());
-        self
-    }
-
-    pub fn scale(mut self, scale: bool) -> Self {
-        self.scale = Some(scale);
-        self
-    }
-
-    pub fn split_number<F: Into<f64>>(mut self, split_number: F) -> Self {
-        self.split_number = Some(split_number.into());
-        self
-    }
-
-    pub fn min_interval<F: Into<f64>>(mut self, min_interval: F) -> Self {
-        self.min_interval = Some(min_interval.into());
-        self
-    }
-
-    pub fn max_interval<F: Into<f64>>(mut self, max_interval: F) -> Self {
-        self.max_interval = Some(max_interval.into());
-        self
-    }
-
-    pub fn interval<F: Into<f64>>(mut self, interval: F) -> Self {
-        self.interval = Some(interval.into());
-        self
-    }
-
-    pub fn log_base<F: Into<f64>>(mut self, log_base: F) -> Self {
-        self.log_base = Some(log_base.into());
-        self
-    }
-
-    pub fn start_value<F: Into<f64>>(mut self, start_value: F) -> Self {
-        self.start_value = Some(start_value.into());
-        self
-    }
-
-    pub fn z_level<F: Into<f64>>(mut self, z_level: F) -> Self {
-        self.z_level = Some(z_level.into());
-        self
-    }
-
-    pub fn z<F: Into<f64>>(mut self, z: F) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
-    pub fn axis_label<L: Into<AxisLabel>>(mut self, axis_label: L) -> Self {
-        self.axis_label = Some(axis_label.into());
-        self
-    }
-
-    pub fn axis_tick<T: Into<AxisTick>>(mut self, axis_tick: T) -> Self {
-        self.axis_tick = Some(axis_tick.into());
-        self
-    }
-
-    pub fn axis_line<L: Into<AxisLine>>(mut self, axis_line: L) -> Self {
-        self.axis_line = Some(axis_line.into());
-        self
-    }
-
-    pub fn axis_pointer<P: Into<AxisPointer>>(mut self, axis_pointer: P) -> Self {
-        self.axis_pointer = Some(axis_pointer.into());
-        self
-    }
-
-    pub fn split_area<A: Into<SplitArea>>(mut self, split_area: A) -> Self {
-        self.split_area = Some(split_area.into());
-        self
-    }
-
-    pub fn split_line<A: Into<SplitLine>>(mut self, split_line: A) -> Self {
-        self.split_line = Some(split_line.into());
-        self
-    }
-
-    pub fn data<S: Into<String>>(mut self, data: Vec<S>) -> Self {
-        self.data = data.into_iter().map(|s| s.into()).collect();
-        self
-    }
 }

--- a/charming/src/component/axis3d.rs
+++ b/charming/src/component/axis3d.rs
@@ -1,27 +1,13 @@
+use crate::element::AxisType;
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use crate::element::AxisType;
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Axis3D {
-    #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<AxisType>,
-}
-
-impl Default for Axis3D {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Axis3D {
-    pub fn new() -> Self {
-        Self { type_: None }
-    }
-
-    pub fn type_<A: Into<AxisType>>(mut self, type_: A) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
 }

--- a/charming/src/component/data_zoom.rs
+++ b/charming/src/component/data_zoom.rs
@@ -1,9 +1,9 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{Color, DataBackground, Orient, TextStyle},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
@@ -25,328 +25,53 @@ pub enum DataZoomType {
 /// DataZoom component is used for zooming a specific area, which enables user
 /// to investigate data in detail, or get an overview of the data, or get rid
 /// of outlier points.
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataZoom {
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     type_: Option<DataZoomType>,
-
     /// Component ID.
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
     /// Whether to show the component.
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
     /// Whether to enable real-time view update.
-    #[serde(skip_serializing_if = "Option::is_none")]
     realtime: Option<bool>,
-
     /// Background color of the component.
-    #[serde(skip_serializing_if = "Option::is_none")]
     background_color: Option<Color>,
-
     /// Style of the data shadow.
-    #[serde(skip_serializing_if = "Option::is_none")]
     data_background: Option<DataBackground>,
-
     /// Style of the selected data shadow.
-    #[serde(skip_serializing_if = "Option::is_none")]
     selected_data_background: Option<DataBackground>,
-
     /// Color to fill selected area.
-    #[serde(skip_serializing_if = "Option::is_none")]
     filler_color: Option<Color>,
-
     /// Color of border.
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     start: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     end: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     start_value: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     end_value: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min_span: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_span: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min_value_span: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_value_span: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     orient: Option<Orient>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     zoom_lock: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     throttle: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis_index: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_index: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     disabled: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     radius_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     angle_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     filter_mode: Option<FilterMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_style: Option<TextStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     handle_icon: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     brush_select: Option<bool>,
-}
-
-impl Default for DataZoom {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DataZoom {
-    pub fn new() -> Self {
-        Self {
-            type_: None,
-            id: None,
-            show: None,
-            realtime: None,
-            background_color: None,
-            data_background: None,
-            selected_data_background: None,
-            filler_color: None,
-            border_color: None,
-            start: None,
-            end: None,
-            start_value: None,
-            end_value: None,
-            min_span: None,
-            max_span: None,
-            min_value_span: None,
-            max_value_span: None,
-            orient: None,
-            zoom_lock: None,
-            throttle: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            x_axis_index: None,
-            y_axis_index: None,
-            disabled: None,
-            radius_axis_index: None,
-            angle_axis_index: None,
-            filter_mode: None,
-            text_style: None,
-            handle_icon: None,
-            brush_select: None,
-        }
-    }
-
-    pub fn type_<T: Into<DataZoomType>>(mut self, type_: T) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn realtime(mut self, realtime: bool) -> Self {
-        self.realtime = Some(realtime);
-        self
-    }
-
-    pub fn background_color<C: Into<Color>>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.into());
-        self
-    }
-
-    pub fn data_background<D: Into<DataBackground>>(mut self, data_background: D) -> Self {
-        self.data_background = Some(data_background.into());
-        self
-    }
-
-    pub fn selected_data_background<D: Into<DataBackground>>(
-        mut self,
-        selected_data_background: D,
-    ) -> Self {
-        self.selected_data_background = Some(selected_data_background.into());
-        self
-    }
-
-    pub fn filler_color<C: Into<Color>>(mut self, filler_color: C) -> Self {
-        self.filler_color = Some(filler_color.into());
-        self
-    }
-
-    pub fn border_color<C: Into<Color>>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.into());
-        self
-    }
-
-    pub fn start<F: Into<f64>>(mut self, start: F) -> Self {
-        self.start = Some(start.into());
-        self
-    }
-
-    pub fn end<F: Into<f64>>(mut self, end: F) -> Self {
-        self.end = Some(end.into());
-        self
-    }
-
-    pub fn start_value<C: Into<CompositeValue>>(mut self, start_value: C) -> Self {
-        self.start_value = Some(start_value.into());
-        self
-    }
-
-    pub fn end_value<C: Into<CompositeValue>>(mut self, end_value: C) -> Self {
-        self.end_value = Some(end_value.into());
-        self
-    }
-
-    pub fn min_span<F: Into<f64>>(mut self, min_span: F) -> Self {
-        self.min_span = Some(min_span.into());
-        self
-    }
-
-    pub fn max_span<F: Into<f64>>(mut self, max_span: F) -> Self {
-        self.max_span = Some(max_span.into());
-        self
-    }
-
-    pub fn min_value_span<F: Into<f64>>(mut self, min_value_span: F) -> Self {
-        self.min_value_span = Some(min_value_span.into());
-        self
-    }
-
-    pub fn max_value_span<F: Into<f64>>(mut self, max_value_span: F) -> Self {
-        self.max_value_span = Some(max_value_span.into());
-        self
-    }
-
-    pub fn orient<O: Into<Orient>>(mut self, orient: O) -> Self {
-        self.orient = Some(orient.into());
-        self
-    }
-
-    pub fn zoom_lock(mut self, zoom_lock: bool) -> Self {
-        self.zoom_lock = Some(zoom_lock);
-        self
-    }
-
-    pub fn throttle<F: Into<f64>>(mut self, throttle: F) -> Self {
-        self.throttle = Some(throttle.into());
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
-    pub fn x_axis_index<C: Into<CompositeValue>>(mut self, x_axis_index: C) -> Self {
-        self.x_axis_index = Some(x_axis_index.into());
-        self
-    }
-
-    pub fn y_axis_index<C: Into<CompositeValue>>(mut self, y_axis_index: C) -> Self {
-        self.y_axis_index = Some(y_axis_index.into());
-        self
-    }
-
-    pub fn disabled(mut self, disabled: bool) -> Self {
-        self.disabled = Some(disabled);
-        self
-    }
-
-    pub fn radius_axis_index<F: Into<f64>>(mut self, radius_axis_index: F) -> Self {
-        self.radius_axis_index = Some(radius_axis_index.into());
-        self
-    }
-
-    pub fn angle_axis_index<F: Into<f64>>(mut self, angle_axis_index: F) -> Self {
-        self.angle_axis_index = Some(angle_axis_index.into());
-        self
-    }
-
-    pub fn filter_mode<F: Into<FilterMode>>(mut self, filter_mode: F) -> Self {
-        self.filter_mode = Some(filter_mode.into());
-        self
-    }
-
-    pub fn text_style<T: Into<TextStyle>>(mut self, text_style: T) -> Self {
-        self.text_style = Some(text_style.into());
-        self
-    }
-
-    pub fn handle_icon<S: Into<String>>(mut self, handle_icon: S) -> Self {
-        self.handle_icon = Some(handle_icon.into());
-        self
-    }
-
-    pub fn brush_select(mut self, brush_select: bool) -> Self {
-        self.brush_select = Some(brush_select);
-        self
-    }
 }

--- a/charming/src/component/geo.rs
+++ b/charming/src/component/geo.rs
@@ -1,150 +1,50 @@
-use serde::Serialize;
-
 use crate::{
     datatype::CompositeValue,
     element::{Blur, Emphasis, ItemStyle, Label, Select},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Geo {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     map: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     roam: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     center: Option<(String, String)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     aspect_scale: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     bounding_coords: Option<((String, String), (String, String))>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     zoom: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     scale_limit: Option<(f64, f64)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     name_map: Option<(String, String)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_property: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     selected_mode: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     select: Option<Select>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     blur: Option<Blur>,
-
     /// The `zlevel` value of all graphical elements in.
-    #[serde(skip_serializing_if = "Option::is_none")]
     zlevel: Option<f64>,
-
     /// The `z` value of all graphical elements in.
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     layout_center: Option<(String, String)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     layout_size: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     silent: Option<bool>,
 }
 
-impl Default for Geo {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Geo {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            map: None,
-            roam: None,
-            center: None,
-            aspect_scale: None,
-            bounding_coords: None,
-            zoom: None,
-            scale_limit: None,
-            name_map: None,
-            name_property: None,
-            selected_mode: None,
-            label: None,
-            item_style: None,
-            emphasis: None,
-            select: None,
-            blur: None,
-            zlevel: None,
-            z: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            layout_center: None,
-            layout_size: None,
-            silent: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn map<S: Into<String>>(mut self, map: S) -> Self {
-        self.map = Some(map.into());
-        self
-    }
-
-    pub fn roam(mut self, roam: bool) -> Self {
-        self.roam = Some(roam);
-        self
-    }
-
     pub fn center<S: Into<String>>(mut self, center: (S, S)) -> Self {
         self.center = Some((center.0.into(), center.1.into()));
-        self
-    }
-
-    pub fn aspect_scale<F: Into<f64>>(mut self, aspect_scale: F) -> Self {
-        self.aspect_scale = Some(aspect_scale.into());
         self
     }
 
@@ -153,11 +53,6 @@ impl Geo {
             ((bounding_coords.0).0.into(), (bounding_coords.0).1.into()),
             ((bounding_coords.1).0.into(), (bounding_coords.1).1.into()),
         ));
-        self
-    }
-
-    pub fn zoom<F: Into<f64>>(mut self, zoom: F) -> Self {
-        self.zoom = Some(zoom.into());
         self
     }
 
@@ -171,83 +66,8 @@ impl Geo {
         self
     }
 
-    pub fn name_property<S: Into<String>>(mut self, name_property: S) -> Self {
-        self.name_property = Some(name_property.into());
-        self
-    }
-
-    pub fn selected_mode(mut self, selected_mode: bool) -> Self {
-        self.selected_mode = Some(selected_mode);
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn item_style<S: Into<ItemStyle>>(mut self, item_style: S) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
-        self
-    }
-
-    pub fn select<S: Into<Select>>(mut self, select: S) -> Self {
-        self.select = Some(select.into());
-        self
-    }
-
-    pub fn blur<B: Into<Blur>>(mut self, blur: B) -> Self {
-        self.blur = Some(blur.into());
-        self
-    }
-
-    pub fn zlevel<F: Into<f64>>(mut self, zlevel: F) -> Self {
-        self.zlevel = Some(zlevel.into());
-        self
-    }
-
-    pub fn z<F: Into<f64>>(mut self, z: F) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
     pub fn layout_center<S: Into<String>>(mut self, layout_center: (S, S)) -> Self {
         self.layout_center = Some((layout_center.0.into(), layout_center.1.into()));
-        self
-    }
-
-    pub fn layout_size<S: Into<String>>(mut self, layout_size: S) -> Self {
-        self.layout_size = Some(layout_size.into());
-        self
-    }
-
-    pub fn silent(mut self, silent: bool) -> Self {
-        self.silent = Some(silent);
         self
     }
 }

--- a/charming/src/component/geo_map.rs
+++ b/charming/src/component/geo_map.rs
@@ -1,3 +1,4 @@
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -20,39 +21,15 @@ where
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GeoMap {
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     opt: Option<GeoMapOpt>,
-}
-
-impl Default for GeoMap {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl GeoMap {
-    pub fn new() -> Self {
-        GeoMap {
-            name: None,
-            opt: None,
-        }
-    }
-
-    pub fn map_name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn opt<M: Into<GeoMapOpt>>(mut self, opt: M) -> Self {
-        self.opt = Some(opt.into());
-        self
-    }
 }
 
 impl From<&str> for GeoMap {
@@ -64,7 +41,7 @@ impl From<&str> for GeoMap {
 impl From<(&str, &str)> for GeoMap {
     fn from((name, svg): (&str, &str)) -> Self {
         GeoMap::new()
-            .map_name(name.to_string())
+            .name(name.to_string())
             .opt(GeoMapOpt::Svg(svg.to_string()))
     }
 }

--- a/charming/src/component/grid.rs
+++ b/charming/src/component/grid.rs
@@ -1,336 +1,93 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{Color, Padding, TextStyle, Trigger},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GridTooltip {
     /// Whether to show the tooltip component.
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
     /// Type of triggering.
-    #[serde(skip_serializing_if = "Option::is_none")]
     trigger: Option<Trigger>,
-
     /// The position of the tooltip's floating layer, which would follow the
     /// position of mouse by default.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     position: Option<(String, String)>,
-
     /// The content formatter of tooltip's floating layer.
-    #[serde(skip_serializing_if = "Option::is_none")]
     formatter: Option<String>,
-
     /// The value formatter of tooltip's floating layer.
-    #[serde(skip_serializing_if = "Option::is_none")]
     value_formatter: Option<String>,
-
     /// The background color of tooltip's floating layer.
-    #[serde(skip_serializing_if = "Option::is_none")]
     background_color: Option<Color>,
-
     /// The border color of tooltip's floating layer.
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_color: Option<Color>,
-
     /// The border width of tooltip's floating layer.
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_width: Option<f64>,
-
     /// The floating layer of tooltip space around content.
-    #[serde(skip_serializing_if = "Option::is_none")]
     padding: Option<Padding>,
-
     /// Text style of tooltip's floating layer.
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_style: Option<TextStyle>,
-
     /// Extra CSS style for the tooltip's floating layer.
-    #[serde(skip_serializing_if = "Option::is_none")]
     extra_css_text: Option<String>,
 }
 
-impl Default for GridTooltip {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl GridTooltip {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            trigger: None,
-            position: None,
-            formatter: None,
-            value_formatter: None,
-            background_color: None,
-            border_color: None,
-            border_width: None,
-            padding: None,
-            text_style: None,
-            extra_css_text: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn trigger<T: Into<Trigger>>(mut self, trigger: T) -> Self {
-        self.trigger = Some(trigger.into());
-        self
-    }
-
     pub fn position<S: Into<String>>(mut self, position: (S, S)) -> Self {
         self.position = Some((position.0.into(), position.1.into()));
         self
     }
-
-    pub fn formatter<S: Into<String>>(mut self, formatter: S) -> Self {
-        self.formatter = Some(formatter.into());
-        self
-    }
-
-    pub fn value_formatter<S: Into<String>>(mut self, value_formatter: S) -> Self {
-        self.value_formatter = Some(value_formatter.into());
-        self
-    }
-
-    pub fn background_color<C: Into<Color>>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.into());
-        self
-    }
-
-    pub fn border_color<C: Into<Color>>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.into());
-        self
-    }
-
-    pub fn border_width<F: Into<f64>>(mut self, border_width: F) -> Self {
-        self.border_width = Some(border_width.into());
-        self
-    }
-
-    pub fn padding<P: Into<Padding>>(mut self, padding: P) -> Self {
-        self.padding = Some(padding.into());
-        self
-    }
-
-    pub fn text_style<T: Into<TextStyle>>(mut self, text_style: T) -> Self {
-        self.text_style = Some(text_style.into());
-        self
-    }
-
-    pub fn extra_css_text<S: Into<String>>(mut self, extra_css_text: S) -> Self {
-        self.extra_css_text = Some(extra_css_text.into());
-        self
-    }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Grid {
     /// Component ID.
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
     /// Whether to show the grid in rectangular coordinate.
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
     /// The `zlevel` value of all graphical elements in.
-    #[serde(skip_serializing_if = "Option::is_none")]
     zlevel: Option<f64>,
-
     /// The `z` value of all graphical elements in.
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
     /// Distance between grid component and the left side of the container.
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
     /// Distance between grid component and the top side of the container.
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
     /// Distance between grid component and the right side of the container.
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
     /// Distance between grid component and the bottom side of the container.
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
     /// Width of grid component.
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<CompositeValue>,
-
     /// Height of grid component.
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<CompositeValue>,
-
     /// Whether the grid region contains axis tick label of axis.
-    #[serde(skip_serializing_if = "Option::is_none")]
     contain_label: Option<bool>,
-
     /// Background color of grid, which is transparent by default.
-    #[serde(skip_serializing_if = "Option::is_none")]
     background_color: Option<Color>,
-
     /// Border color of grid.
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_color: Option<Color>,
-
     /// Border width of grid.
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_width: Option<f64>,
-
     /// Size of shadow blue.
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_blur: Option<f64>,
-
     /// Shadow color.
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_color: Option<Color>,
-
     /// Offset distance on the horizontal direction of shadow.
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_offset_x: Option<f64>,
-
     /// Offset distance on the vertical direction of shadow.
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_offset_y: Option<f64>,
-
     /// Tooltip settings in the grid.
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<GridTooltip>,
-}
-
-impl Default for Grid {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Grid {
-    pub fn new() -> Self {
-        Self {
-            id: None,
-            show: None,
-            zlevel: None,
-            z: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            width: None,
-            height: None,
-            contain_label: None,
-            background_color: None,
-            border_color: None,
-            border_width: None,
-            shadow_blur: None,
-            shadow_color: None,
-            shadow_offset_x: None,
-            shadow_offset_y: None,
-            tooltip: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn zlevel<F: Into<f64>>(mut self, zlevel: F) -> Self {
-        self.zlevel = Some(zlevel.into());
-        self
-    }
-
-    pub fn z<F: Into<f64>>(mut self, z: F) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
-    pub fn width<C: Into<CompositeValue>>(mut self, width: C) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn height<C: Into<CompositeValue>>(mut self, height: C) -> Self {
-        self.height = Some(height.into());
-        self
-    }
-
-    pub fn contain_label(mut self, contain_label: bool) -> Self {
-        self.contain_label = Some(contain_label);
-        self
-    }
-
-    pub fn background_color<C: Into<Color>>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.into());
-        self
-    }
-
-    pub fn border_color<C: Into<Color>>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.into());
-        self
-    }
-
-    pub fn border_width<F: Into<f64>>(mut self, border_width: F) -> Self {
-        self.border_width = Some(border_width.into());
-        self
-    }
-
-    pub fn shadow_blur<F: Into<f64>>(mut self, shadow_blur: F) -> Self {
-        self.shadow_blur = Some(shadow_blur.into());
-        self
-    }
-
-    pub fn shadow_color<C: Into<Color>>(mut self, shadow_color: C) -> Self {
-        self.shadow_color = Some(shadow_color.into());
-        self
-    }
-
-    pub fn shadow_offset_x<F: Into<f64>>(mut self, shadow_offset_x: F) -> Self {
-        self.shadow_offset_x = Some(shadow_offset_x.into());
-        self
-    }
-
-    pub fn shadow_offset_y<F: Into<f64>>(mut self, shadow_offset_y: F) -> Self {
-        self.shadow_offset_y = Some(shadow_offset_y.into());
-        self
-    }
-
-    pub fn tooltip<T: Into<GridTooltip>>(mut self, tooltip: T) -> Self {
-        self.tooltip = Some(tooltip.into());
-        self
-    }
 }

--- a/charming/src/component/grid3d.rs
+++ b/charming/src/component/grid3d.rs
@@ -1,17 +1,6 @@
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Grid3D {}
-
-impl Default for Grid3D {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Grid3D {
-    pub fn new() -> Self {
-        Self {}
-    }
-}

--- a/charming/src/component/legend.rs
+++ b/charming/src/component/legend.rs
@@ -1,13 +1,12 @@
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{
         AnimationTime, Color, Icon, ItemStyle, LabelAlign, LineStyle, Orient, Padding, TextStyle,
     },
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(untagged)]
@@ -90,301 +89,74 @@ impl From<(String, String)> for LegendItem {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Legend {
     /// Type of legend.
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     type_: Option<LegendType>,
-
     /// Component ID.
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
     /// Whether to show the legend component.
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
     /// The `zlevel` value of all graphical elements in.
-    #[serde(skip_serializing_if = "Option::is_none")]
     zlevel: Option<f64>,
-
     /// The `z` value of all graphical elements in.
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
     /// Distance between title component and the left side of the container.
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
     /// Distance between title component and the top side of the container.
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
     /// Distance between title component and the right side of the container.
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
     /// Distance between title component and the bottom side of the container.
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
     /// Width of legend component.
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<CompositeValue>,
-
     /// Height of legend component.
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<CompositeValue>,
-
     /// The layout orientation of legend.
-    #[serde(skip_serializing_if = "Option::is_none")]
     orient: Option<Orient>,
-
     /// The align of legend.
-    #[serde(skip_serializing_if = "Option::is_none")]
     align: Option<LabelAlign>,
-
     /// Legend padding.
-    #[serde(skip_serializing_if = "Option::is_none")]
     padding: Option<Padding>,
-
     /// The gap between each legend.
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_gap: Option<f64>,
-
     /// Width of legend symbol.
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_width: Option<f64>,
-
     /// Height of legend symbol.
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_height: Option<f64>,
-
     /// Legend item style.
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
     /// Legend line style.
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_style: Option<TextStyle>,
-
     /// Rotation of the symbol.
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_rotate: Option<String>,
-
     /// Formatter is used to format label of legend.
-    #[serde(skip_serializing_if = "Option::is_none")]
     formatter: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     selected: Option<BTreeMap<String, bool>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     selected_mode: Option<LegendSelectedMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     inactive_color: Option<Color>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<LegendItem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation_duration_update: Option<AnimationTime>,
 }
 
-impl Default for Legend {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Legend {
-    pub fn new() -> Self {
-        Self {
-            type_: None,
-            id: None,
-            show: None,
-            zlevel: None,
-            z: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            width: None,
-            height: None,
-            orient: None,
-            align: None,
-            padding: None,
-            item_gap: None,
-            item_width: None,
-            item_height: None,
-            item_style: None,
-            line_style: None,
-            text_style: None,
-            symbol_rotate: None,
-            formatter: None,
-            selected: None,
-            selected_mode: None,
-            border_color: None,
-            inactive_color: None,
-            data: vec![],
-            animation: None,
-            animation_duration_update: None,
-        }
-    }
-
-    pub fn type_<T: Into<LegendType>>(mut self, type_: T) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn zlevel<F: Into<f64>>(mut self, zlevel: F) -> Self {
-        self.zlevel = Some(zlevel.into());
-        self
-    }
-
-    pub fn z<F: Into<f64>>(mut self, z: F) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
-    pub fn width<C: Into<CompositeValue>>(mut self, width: C) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn height<C: Into<CompositeValue>>(mut self, height: C) -> Self {
-        self.height = Some(height.into());
-        self
-    }
-
-    pub fn orient<O: Into<Orient>>(mut self, orient: O) -> Self {
-        self.orient = Some(orient.into());
-        self
-    }
-
-    pub fn align<A: Into<LabelAlign>>(mut self, align: A) -> Self {
-        self.align = Some(align.into());
-        self
-    }
-
-    pub fn padding<P: Into<Padding>>(mut self, padding: P) -> Self {
-        self.padding = Some(padding.into());
-        self
-    }
-
-    pub fn item_gap<F: Into<f64>>(mut self, item_gap: F) -> Self {
-        self.item_gap = Some(item_gap.into());
-        self
-    }
-
-    pub fn item_width<F: Into<f64>>(mut self, item_width: F) -> Self {
-        self.item_width = Some(item_width.into());
-        self
-    }
-
-    pub fn item_height<F: Into<f64>>(mut self, item_height: F) -> Self {
-        self.item_height = Some(item_height.into());
-        self
-    }
-
-    pub fn item_style<S: Into<ItemStyle>>(mut self, item_style: S) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn line_style<S: Into<LineStyle>>(mut self, line_style: S) -> Self {
-        self.line_style = Some(line_style.into());
-        self
-    }
-
-    pub fn text_style<S: Into<TextStyle>>(mut self, text_style: S) -> Self {
-        self.text_style = Some(text_style.into());
-        self
-    }
-
-    pub fn symbol_rotate<S: Into<String>>(mut self, symbol_rotate: S) -> Self {
-        self.symbol_rotate = Some(symbol_rotate.into());
-        self
-    }
-
-    pub fn formatter<S: Into<String>>(mut self, formatter: S) -> Self {
-        self.formatter = Some(formatter.into());
-        self
-    }
-
     pub fn selected<S: Into<String>, I: IntoIterator<Item = (S, bool)>>(
         mut self,
         selected: I,
     ) -> Self {
         self.selected = Some(selected.into_iter().map(|(k, v)| (k.into(), v)).collect());
-        self
-    }
-
-    pub fn selected_mode<S: Into<LegendSelectedMode>>(mut self, selected_mode: S) -> Self {
-        self.selected_mode = Some(selected_mode.into());
-        self
-    }
-
-    pub fn border_color<C: Into<Color>>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.into());
-        self
-    }
-
-    pub fn inactive_color<C: Into<Color>>(mut self, inactive_color: C) -> Self {
-        self.inactive_color = Some(inactive_color.into());
-        self
-    }
-
-    pub fn data<L: Into<LegendItem>>(mut self, data: Vec<L>) -> Self {
-        self.data = data.into_iter().map(|s| s.into()).collect();
-        self
-    }
-
-    pub fn animation(mut self, animation: bool) -> Self {
-        self.animation = Some(animation);
-        self
-    }
-
-    pub fn animation_duration_update<A: Into<AnimationTime>>(mut self, animation_time: A) -> Self {
-        self.animation_duration_update = Some(animation_time.into());
         self
     }
 }

--- a/charming/src/component/parallel_axis.rs
+++ b/charming/src/component/parallel_axis.rs
@@ -1,130 +1,26 @@
+use crate::element::{AxisType, NameLocation};
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use crate::element::{AxisType, NameLocation};
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ParallelAxis {
-    #[serde(skip_serializing_if = "Option::is_none")]
     dim: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     parallel_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     realtime: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     type_: Option<AxisType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_location: Option<NameLocation>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_gap: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     inverse: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     start_value: Option<f64>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<String>,
-}
-
-impl Default for ParallelAxis {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ParallelAxis {
-    pub fn new() -> Self {
-        Self {
-            dim: None,
-            parallel_index: None,
-            realtime: None,
-            type_: None,
-            name: None,
-            name_location: None,
-            name_gap: None,
-            inverse: None,
-            max: None,
-            min: None,
-            start_value: None,
-            data: vec![],
-        }
-    }
-
-    pub fn dim<F: Into<f64>>(mut self, dim: F) -> Self {
-        self.dim = Some(dim.into());
-        self
-    }
-
-    pub fn parallel_index<F: Into<f64>>(mut self, parallel_index: F) -> Self {
-        self.parallel_index = Some(parallel_index.into());
-        self
-    }
-
-    pub fn realtime(mut self, realtime: bool) -> Self {
-        self.realtime = Some(realtime);
-        self
-    }
-
-    pub fn type_<S: Into<AxisType>>(mut self, type_: S) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn name_location<E: Into<NameLocation>>(mut self, name_location: E) -> Self {
-        self.name_location = Some(name_location.into());
-        self
-    }
-
-    pub fn name_gap<F: Into<f64>>(mut self, name_gap: F) -> Self {
-        self.name_gap = Some(name_gap.into());
-        self
-    }
-
-    pub fn inverse(mut self, inverse: bool) -> Self {
-        self.inverse = Some(inverse);
-        self
-    }
-
-    pub fn max<F: Into<f64>>(mut self, max: F) -> Self {
-        self.max = Some(max.into());
-        self
-    }
-
-    pub fn min<F: Into<f64>>(mut self, min: F) -> Self {
-        self.min = Some(min.into());
-        self
-    }
-
-    pub fn start_value<F: Into<f64>>(mut self, start_value: F) -> Self {
-        self.start_value = Some(start_value.into());
-        self
-    }
-
-    pub fn data<S: Into<String>>(mut self, data: Vec<S>) -> Self {
-        self.data = data.into_iter().map(|s| s.into()).collect();
-        self
-    }
 }

--- a/charming/src/component/parallel_coordinate.rs
+++ b/charming/src/component/parallel_coordinate.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{
@@ -7,348 +5,59 @@ use crate::{
         SplitLine, TextStyle,
     },
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ParallelAxisDefault {
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     type_: Option<AxisType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_location: Option<NameLocation>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_text_style: Option<TextStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_gap: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_rotate: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     inverse: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     boundary_gap: Option<BoundaryGap>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     scale: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_number: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min_interval: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_interval: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     interval: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     log_base: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     silent: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     trigger_event: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_line: Option<AxisLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_tick: Option<AxisTick>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_label: Option<AxisLabel>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_line: Option<SplitLine>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<String>,
 }
 
-impl Default for ParallelAxisDefault {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ParallelAxisDefault {
-    pub fn new() -> Self {
-        Self {
-            type_: None,
-            name: None,
-            name_location: None,
-            name_text_style: None,
-            name_gap: None,
-            name_rotate: None,
-            inverse: None,
-            boundary_gap: None,
-            min: None,
-            max: None,
-            scale: None,
-            split_number: None,
-            min_interval: None,
-            max_interval: None,
-            interval: None,
-            log_base: None,
-            silent: None,
-            trigger_event: None,
-            axis_line: None,
-            axis_tick: None,
-            axis_label: None,
-            split_line: None,
-            data: vec![],
-        }
-    }
-
-    pub fn type_<S: Into<AxisType>>(mut self, type_: S) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn name_location<S: Into<NameLocation>>(mut self, name_location: S) -> Self {
-        self.name_location = Some(name_location.into());
-        self
-    }
-
-    pub fn name_text_style<T: Into<TextStyle>>(mut self, name_text_style: T) -> Self {
-        self.name_text_style = Some(name_text_style.into());
-        self
-    }
-
-    pub fn name_gap<F: Into<f64>>(mut self, name_gap: F) -> Self {
-        self.name_gap = Some(name_gap.into());
-        self
-    }
-
-    pub fn name_rotate<F: Into<f64>>(mut self, name_rotate: F) -> Self {
-        self.name_rotate = Some(name_rotate.into());
-        self
-    }
-
-    pub fn inverse(mut self, inverse: bool) -> Self {
-        self.inverse = Some(inverse);
-        self
-    }
-
-    pub fn boundary_gap<B: Into<BoundaryGap>>(mut self, boundary_gap: B) -> Self {
-        self.boundary_gap = Some(boundary_gap.into());
-        self
-    }
-
-    pub fn min<F: Into<f64>>(mut self, min: F) -> Self {
-        self.min = Some(min.into());
-        self
-    }
-
-    pub fn max<F: Into<f64>>(mut self, max: F) -> Self {
-        self.max = Some(max.into());
-        self
-    }
-
-    pub fn scale(mut self, scale: bool) -> Self {
-        self.scale = Some(scale);
-        self
-    }
-
-    pub fn split_number<F: Into<f64>>(mut self, split_number: F) -> Self {
-        self.split_number = Some(split_number.into());
-        self
-    }
-
-    pub fn min_interval<F: Into<f64>>(mut self, min_interval: F) -> Self {
-        self.min_interval = Some(min_interval.into());
-        self
-    }
-
-    pub fn max_interval<F: Into<f64>>(mut self, max_interval: F) -> Self {
-        self.max_interval = Some(max_interval.into());
-        self
-    }
-
-    pub fn interval<F: Into<f64>>(mut self, interval: F) -> Self {
-        self.interval = Some(interval.into());
-        self
-    }
-
-    pub fn log_base<F: Into<f64>>(mut self, log_base: F) -> Self {
-        self.log_base = Some(log_base.into());
-        self
-    }
-
-    pub fn silent(mut self, silent: bool) -> Self {
-        self.silent = Some(silent);
-        self
-    }
-
-    pub fn trigger_event(mut self, trigger_event: bool) -> Self {
-        self.trigger_event = Some(trigger_event);
-        self
-    }
-
-    pub fn axis_line<A: Into<AxisLine>>(mut self, axis_line: A) -> Self {
-        self.axis_line = Some(axis_line.into());
-        self
-    }
-
-    pub fn axis_tick<A: Into<AxisTick>>(mut self, axis_tick: A) -> Self {
-        self.axis_tick = Some(axis_tick.into());
-        self
-    }
-
-    pub fn axis_label<A: Into<AxisLabel>>(mut self, axis_label: A) -> Self {
-        self.axis_label = Some(axis_label.into());
-        self
-    }
-
-    pub fn split_line<S: Into<SplitLine>>(mut self, split_line: S) -> Self {
-        self.split_line = Some(split_line.into());
-        self
-    }
-
-    pub fn data<S: Into<String>>(mut self, data: Vec<S>) -> Self {
-        self.data = data.into_iter().map(|s| s.into()).collect();
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ParallelCoordinate {
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     zlevel: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     layout: Option<ParallelLayout>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     parallel_axis_default: Option<ParallelAxisDefault>,
-}
-
-impl Default for ParallelCoordinate {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ParallelCoordinate {
-    pub fn new() -> Self {
-        Self {
-            id: None,
-            zlevel: None,
-            z: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            width: None,
-            height: None,
-            layout: None,
-            parallel_axis_default: None,
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn zlevel<F: Into<f64>>(mut self, zlevel: F) -> Self {
-        self.zlevel = Some(zlevel.into());
-        self
-    }
-
-    pub fn z<F: Into<f64>>(mut self, z: F) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
-    pub fn width<C: Into<CompositeValue>>(mut self, width: C) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn height<C: Into<CompositeValue>>(mut self, height: C) -> Self {
-        self.height = Some(height.into());
-        self
-    }
-
-    pub fn layout<L: Into<ParallelLayout>>(mut self, layout: L) -> Self {
-        self.layout = Some(layout.into());
-        self
-    }
-
-    pub fn parallel_axis_default<A: Into<ParallelAxisDefault>>(
-        mut self,
-        parallel_axis_default: A,
-    ) -> Self {
-        self.parallel_axis_default = Some(parallel_axis_default.into());
-        self
-    }
 }

--- a/charming/src/component/polar_coordinate.rs
+++ b/charming/src/component/polar_coordinate.rs
@@ -1,68 +1,20 @@
+use crate::datatype::CompositeValue;
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use crate::datatype::CompositeValue;
-
 /// Polar coordinate can be used in scatter and line chart.
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PolarCoordinate {
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
     /// The `zlevel` value of all graphical elements in.
-    #[serde(skip_serializing_if = "Option::is_none")]
     zlevel: Option<f64>,
-
     /// The `z` value of all graphical elements in.
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     center: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     radius: Option<CompositeValue>,
-}
-
-impl Default for PolarCoordinate {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PolarCoordinate {
-    pub fn new() -> Self {
-        Self {
-            id: None,
-            zlevel: None,
-            z: None,
-            center: None,
-            radius: None,
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn zlevel<F: Into<f64>>(mut self, zlevel: F) -> Self {
-        self.zlevel = Some(zlevel.into());
-        self
-    }
-
-    pub fn z<F: Into<f64>>(mut self, z: F) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
-    pub fn center<C: Into<CompositeValue>>(mut self, center: C) -> Self {
-        self.center = Some(center.into());
-        self
-    }
-
-    pub fn radius<C: Into<CompositeValue>>(mut self, radius: C) -> Self {
-        self.radius = Some(radius.into());
-        self
-    }
 }

--- a/charming/src/component/radar_coordinate.rs
+++ b/charming/src/component/radar_coordinate.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{
@@ -7,348 +5,62 @@ use crate::{
         AxisLabel, AxisLine, AxisTick, Color, Formatter, Padding, Shape, SplitArea, SplitLine,
     },
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 /// Name options for radar indicators.
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadarAxisName {
     /// Whether to display the indicator's name.
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
     /// Formatter of the indicator's name.
-    #[serde(skip_serializing_if = "Option::is_none")]
     formatter: Option<Formatter>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_style: Option<FontStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_weight: Option<FontWeight>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_family: Option<FontFamily>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_size: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_height: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     background_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_width: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_dash_offset: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_radius: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     padding: Option<Padding>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_blur: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_offset_x: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_offset_y: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_border_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_border_width: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_border_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_border_dash_offset: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_shadow_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_shadow_blur: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_shadow_offset_x: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_shadow_offset_y: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     overflow: Option<String>,
 }
 
-impl Default for RadarAxisName {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl RadarAxisName {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            formatter: None,
-            color: None,
-            font_style: None,
-            font_weight: None,
-            font_family: None,
-            font_size: None,
-            line_height: None,
-            background_color: None,
-            border_color: None,
-            border_width: None,
-            border_type: None,
-            border_dash_offset: None,
-            border_radius: None,
-            padding: None,
-            shadow_color: None,
-            shadow_blur: None,
-            shadow_offset_x: None,
-            shadow_offset_y: None,
-            width: None,
-            height: None,
-            text_border_color: None,
-            text_border_width: None,
-            text_border_type: None,
-            text_border_dash_offset: None,
-            text_shadow_color: None,
-            text_shadow_blur: None,
-            text_shadow_offset_x: None,
-            text_shadow_offset_y: None,
-            overflow: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn formatter<C: Into<Formatter>>(mut self, formatter: C) -> Self {
-        self.formatter = Some(formatter.into());
-        self
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
-        self.color = Some(color.into());
-        self
-    }
-
-    pub fn font_style<F: Into<FontStyle>>(mut self, font_style: F) -> Self {
-        self.font_style = Some(font_style.into());
-        self
-    }
-
-    pub fn font_weight<F: Into<FontWeight>>(mut self, font_weight: F) -> Self {
-        self.font_weight = Some(font_weight.into());
-        self
-    }
-
-    pub fn font_family<F: Into<FontFamily>>(mut self, font_family: F) -> Self {
-        self.font_family = Some(font_family.into());
-        self
-    }
-
-    pub fn font_size<F: Into<f64>>(mut self, font_size: F) -> Self {
-        self.font_size = Some(font_size.into());
-        self
-    }
-
-    pub fn line_height<F: Into<f64>>(mut self, line_height: F) -> Self {
-        self.line_height = Some(line_height.into());
-        self
-    }
-
-    pub fn background_color<C: Into<Color>>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.into());
-        self
-    }
-
-    pub fn border_color<C: Into<Color>>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.into());
-        self
-    }
-
-    pub fn border_width<F: Into<f64>>(mut self, border_width: F) -> Self {
-        self.border_width = Some(border_width.into());
-        self
-    }
-
-    pub fn border_type<S: Into<String>>(mut self, border_type: S) -> Self {
-        self.border_type = Some(border_type.into());
-        self
-    }
-
-    pub fn border_dash_offset<F: Into<f64>>(mut self, border_dash_offset: F) -> Self {
-        self.border_dash_offset = Some(border_dash_offset.into());
-        self
-    }
-
-    pub fn border_radius<C: Into<CompositeValue>>(mut self, border_radius: C) -> Self {
-        self.border_radius = Some(border_radius.into());
-        self
-    }
-
-    pub fn padding<C: Into<Padding>>(mut self, padding: C) -> Self {
-        self.padding = Some(padding.into());
-        self
-    }
-
-    pub fn shadow_color<C: Into<Color>>(mut self, shadow_color: C) -> Self {
-        self.shadow_color = Some(shadow_color.into());
-        self
-    }
-
-    pub fn shadow_blur<F: Into<f64>>(mut self, shadow_blur: F) -> Self {
-        self.shadow_blur = Some(shadow_blur.into());
-        self
-    }
-
-    pub fn shadow_offset_x<F: Into<f64>>(mut self, shadow_offset_x: F) -> Self {
-        self.shadow_offset_x = Some(shadow_offset_x.into());
-        self
-    }
-
-    pub fn shadow_offset_y<F: Into<f64>>(mut self, shadow_offset_y: F) -> Self {
-        self.shadow_offset_y = Some(shadow_offset_y.into());
-        self
-    }
-
-    pub fn width<C: Into<CompositeValue>>(mut self, width: C) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn height<C: Into<CompositeValue>>(mut self, height: C) -> Self {
-        self.height = Some(height.into());
-        self
-    }
-
-    pub fn text_border_color<C: Into<Color>>(mut self, text_border_color: C) -> Self {
-        self.text_border_color = Some(text_border_color.into());
-        self
-    }
-
-    pub fn text_border_width<F: Into<f64>>(mut self, text_border_width: F) -> Self {
-        self.text_border_width = Some(text_border_width.into());
-        self
-    }
-
-    pub fn text_border_type<S: Into<String>>(mut self, text_border_type: S) -> Self {
-        self.text_border_type = Some(text_border_type.into());
-        self
-    }
-
-    pub fn text_border_dash_offset<F: Into<f64>>(mut self, text_border_dash_offset: F) -> Self {
-        self.text_border_dash_offset = Some(text_border_dash_offset.into());
-        self
-    }
-
-    pub fn text_shadow_color<C: Into<Color>>(mut self, text_shadow_color: C) -> Self {
-        self.text_shadow_color = Some(text_shadow_color.into());
-        self
-    }
-
-    pub fn text_shadow_blur<F: Into<f64>>(mut self, text_shadow_blur: F) -> Self {
-        self.text_shadow_blur = Some(text_shadow_blur.into());
-        self
-    }
-
-    pub fn text_shadow_offset_x<F: Into<f64>>(mut self, text_shadow_offset_x: F) -> Self {
-        self.text_shadow_offset_x = Some(text_shadow_offset_x.into());
-        self
-    }
-
-    pub fn text_shadow_offset_y<F: Into<f64>>(mut self, text_shadow_offset_y: F) -> Self {
-        self.text_shadow_offset_y = Some(text_shadow_offset_y.into());
-        self
-    }
-
-    pub fn overflow<S: Into<String>>(mut self, overflow: S) -> Self {
-        self.overflow = Some(overflow.into());
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadarIndicator {
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-}
-
-impl Default for RadarIndicator {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl RadarIndicator {
-    pub fn new() -> Self {
-        Self {
-            name: None,
-            max: None,
-            min: None,
-            color: None,
-        }
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn max(mut self, max: impl Into<f64>) -> Self {
-        self.max = Some(max.into());
-        self
-    }
-
-    pub fn min(mut self, min: impl Into<f64>) -> Self {
-        self.min = Some(min.into());
-        self
-    }
-
-    pub fn color(mut self, color: Color) -> Self {
-        self.color = Some(color);
-        self
-    }
 }
 
 impl From<(&str, f64, f64)> for RadarIndicator {
@@ -373,160 +85,31 @@ impl From<(&str, i64, i64)> for RadarIndicator {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadarCoordinate {
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
     /// The `zlevel` value of all graphical elements in.
-    #[serde(skip_serializing_if = "Option::is_none")]
     zlevel: Option<f64>,
-
     /// The `z` value of all graphical elements in.
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     center: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     radius: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     start_angle: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_name: Option<RadarAxisName>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_gap: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_number: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shape: Option<Shape>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     scale: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_line: Option<AxisLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_tick: Option<AxisTick>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_label: Option<AxisLabel>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_line: Option<SplitLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_area: Option<SplitArea>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     indicator: Vec<RadarIndicator>,
-}
-
-impl Default for RadarCoordinate {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl RadarCoordinate {
-    pub fn new() -> Self {
-        Self {
-            id: None,
-            zlevel: None,
-            z: None,
-            center: None,
-            radius: None,
-            start_angle: None,
-            axis_name: None,
-            name_gap: None,
-            split_number: None,
-            shape: None,
-            scale: None,
-            axis_line: None,
-            axis_tick: None,
-            axis_label: None,
-            split_line: None,
-            split_area: None,
-            indicator: vec![],
-        }
-    }
-
-    pub fn center<C: Into<CompositeValue>>(mut self, center: C) -> Self {
-        self.center = Some(center.into());
-        self
-    }
-
-    pub fn radius<C: Into<CompositeValue>>(mut self, radius: C) -> Self {
-        self.radius = Some(radius.into());
-        self
-    }
-
-    pub fn start_angle<F: Into<f64>>(mut self, start_angle: F) -> Self {
-        self.start_angle = Some(start_angle.into());
-        self
-    }
-
-    pub fn axis_name<R: Into<RadarAxisName>>(mut self, axis_name: R) -> Self {
-        self.axis_name = Some(axis_name.into());
-        self
-    }
-
-    pub fn name_gap<F: Into<f64>>(mut self, name_gap: F) -> Self {
-        self.name_gap = Some(name_gap.into());
-        self
-    }
-
-    pub fn split_number<F: Into<f64>>(mut self, split_number: F) -> Self {
-        self.split_number = Some(split_number.into());
-        self
-    }
-
-    pub fn shape<S: Into<Shape>>(mut self, shape: S) -> Self {
-        self.shape = Some(shape.into());
-        self
-    }
-
-    pub fn scale(mut self, scale: bool) -> Self {
-        self.scale = Some(scale);
-        self
-    }
-
-    pub fn axis_line<L: Into<AxisLine>>(mut self, axis_line: L) -> Self {
-        self.axis_line = Some(axis_line.into());
-        self
-    }
-
-    pub fn axis_tick<T: Into<AxisTick>>(mut self, axis_tick: T) -> Self {
-        self.axis_tick = Some(axis_tick.into());
-        self
-    }
-
-    pub fn axis_label<L: Into<AxisLabel>>(mut self, axis_label: L) -> Self {
-        self.axis_label = Some(axis_label.into());
-        self
-    }
-
-    pub fn split_line<L: Into<SplitLine>>(mut self, split_line: L) -> Self {
-        self.split_line = Some(split_line.into());
-        self
-    }
-
-    pub fn split_area<A: Into<SplitArea>>(mut self, split_area: A) -> Self {
-        self.split_area = Some(split_area.into());
-        self
-    }
-
-    pub fn indicator<I: Into<RadarIndicator>>(mut self, indicator: Vec<I>) -> Self {
-        self.indicator = indicator.into_iter().map(|i| i.into()).collect();
-        self
-    }
 }

--- a/charming/src/component/radius_axis.rs
+++ b/charming/src/component/radius_axis.rs
@@ -1,220 +1,36 @@
+use crate::element::{AxisLabel, AxisLine, AxisType, BoundaryGap, NameLocation, TextStyle};
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use crate::element::{AxisLabel, AxisLine, AxisType, BoundaryGap, NameLocation, TextStyle};
-
 /// Radius axis in polar coordinate.
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RadiusAxis {
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     polar_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<AxisType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_location: Option<NameLocation>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_text_style: Option<TextStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_gap: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name_rotation: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     inverse: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     boundary_gap: Option<BoundaryGap>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     scale: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_number: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min_interval: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_interval: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     interval: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     log_base: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     start_value: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_label: Option<AxisLabel>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_line: Option<AxisLine>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<String>,
-}
-
-impl Default for RadiusAxis {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl RadiusAxis {
-    pub fn new() -> Self {
-        Self {
-            id: None,
-            polar_index: None,
-            type_: None,
-            name: None,
-            name_location: None,
-            name_text_style: None,
-            name_gap: None,
-            name_rotation: None,
-            inverse: None,
-            boundary_gap: None,
-            min: None,
-            max: None,
-            scale: None,
-            split_number: None,
-            min_interval: None,
-            max_interval: None,
-            interval: None,
-            log_base: None,
-            start_value: None,
-            axis_label: None,
-            axis_line: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn polar_index<F: Into<f64>>(mut self, polar_index: F) -> Self {
-        self.polar_index = Some(polar_index.into());
-        self
-    }
-
-    pub fn type_<T: Into<AxisType>>(mut self, type_: T) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn name_location<L: Into<NameLocation>>(mut self, name_location: L) -> Self {
-        self.name_location = Some(name_location.into());
-        self
-    }
-
-    pub fn name_text_style<T: Into<TextStyle>>(mut self, name_text_style: T) -> Self {
-        self.name_text_style = Some(name_text_style.into());
-        self
-    }
-
-    pub fn name_gap<F: Into<f64>>(mut self, name_gap: F) -> Self {
-        self.name_gap = Some(name_gap.into());
-        self
-    }
-
-    pub fn name_rotation<F: Into<f64>>(mut self, name_rotation: F) -> Self {
-        self.name_rotation = Some(name_rotation.into());
-        self
-    }
-
-    pub fn inverse(mut self, inverse: bool) -> Self {
-        self.inverse = Some(inverse);
-        self
-    }
-
-    pub fn boundary_gap<B: Into<BoundaryGap>>(mut self, boundary_gap: B) -> Self {
-        self.boundary_gap = Some(boundary_gap.into());
-        self
-    }
-
-    pub fn min<F: Into<f64>>(mut self, min: F) -> Self {
-        self.min = Some(min.into());
-        self
-    }
-
-    pub fn max<F: Into<f64>>(mut self, max: F) -> Self {
-        self.max = Some(max.into());
-        self
-    }
-
-    pub fn scale(mut self, scale: bool) -> Self {
-        self.scale = Some(scale);
-        self
-    }
-
-    pub fn split_number<F: Into<f64>>(mut self, split_number: F) -> Self {
-        self.split_number = Some(split_number.into());
-        self
-    }
-
-    pub fn min_interval<F: Into<f64>>(mut self, min_interval: F) -> Self {
-        self.min_interval = Some(min_interval.into());
-        self
-    }
-
-    pub fn max_interval<F: Into<f64>>(mut self, max_interval: F) -> Self {
-        self.max_interval = Some(max_interval.into());
-        self
-    }
-
-    pub fn interval<F: Into<f64>>(mut self, interval: F) -> Self {
-        self.interval = Some(interval.into());
-        self
-    }
-
-    pub fn log_base<F: Into<f64>>(mut self, log_base: F) -> Self {
-        self.log_base = Some(log_base.into());
-        self
-    }
-
-    pub fn start_value<F: Into<f64>>(mut self, start_value: F) -> Self {
-        self.start_value = Some(start_value.into());
-        self
-    }
-
-    pub fn axis_label<A: Into<AxisLabel>>(mut self, axis_label: A) -> Self {
-        self.axis_label = Some(axis_label.into());
-        self
-    }
-
-    pub fn axis_line<A: Into<AxisLine>>(mut self, axis_line: A) -> Self {
-        self.axis_line = Some(axis_line.into());
-        self
-    }
-
-    pub fn data<S: Into<String>>(mut self, data: Vec<S>) -> Self {
-        self.data = data.into_iter().map(|s| s.into()).collect();
-        self
-    }
 }

--- a/charming/src/component/single_axis.rs
+++ b/charming/src/component/single_axis.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{datatype::CompositeValue, element::Orient};
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -11,137 +11,25 @@ pub enum Type {
     Log,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SingleAxis {
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     type_: Option<Type>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     orient: Option<Orient>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     inverse: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     start_value: Option<f64>,
-}
-
-impl Default for SingleAxis {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SingleAxis {
-    pub fn new() -> Self {
-        Self {
-            type_: None,
-            name: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            width: None,
-            height: None,
-            orient: None,
-            inverse: None,
-            min: None,
-            max: None,
-            start_value: None,
-        }
-    }
-
-    pub fn type_(mut self, type_: Type) -> Self {
-        self.type_ = Some(type_);
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
-    pub fn width<C: Into<CompositeValue>>(mut self, width: C) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn height<C: Into<CompositeValue>>(mut self, height: C) -> Self {
-        self.height = Some(height.into());
-        self
-    }
-
-    pub fn orient(mut self, orient: Orient) -> Self {
-        self.orient = Some(orient);
-        self
-    }
-
-    pub fn inverse(mut self, inverse: bool) -> Self {
-        self.inverse = Some(inverse);
-        self
-    }
-
-    pub fn min<S: Into<String>>(mut self, min: S) -> Self {
-        self.min = Some(min.into());
-        self
-    }
-
-    pub fn max<S: Into<String>>(mut self, max: S) -> Self {
-        self.max = Some(max.into());
-        self
-    }
-
-    pub fn start_value<F: Into<f64>>(mut self, start_value: F) -> Self {
-        self.start_value = Some(start_value.into());
-        self
-    }
 }

--- a/charming/src/component/title.rs
+++ b/charming/src/component/title.rs
@@ -1,302 +1,72 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{Color, LinkTarget, Padding, TextAlign, TextStyle, TextVerticalAlign},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 /// Title component, including main title and subtitle.
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Title {
     /// Component ID.
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
     /// Whether to show the title component.
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
     /// The main title text, supporting for `\n` for newlines.
-    #[serde(skip_serializing_if = "Option::is_none")]
     text: Option<String>,
-
     /// The hyper link of main title text.
-    #[serde(skip_serializing_if = "Option::is_none")]
     link: Option<String>,
-
     /// Open the hyper link of main title in specified target.
-    #[serde(skip_serializing_if = "Option::is_none")]
     target: Option<LinkTarget>,
-
     /// The text style of main title.
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_style: Option<TextStyle>,
-
     /// The sub title text, supporting for `\n` for newlines.
-    #[serde(skip_serializing_if = "Option::is_none")]
     subtext: Option<String>,
-
     /// The hyper link of sub title text.
-    #[serde(skip_serializing_if = "Option::is_none")]
     sublink: Option<String>,
-
     /// Open the hyper link of sub title in specified target.
-    #[serde(skip_serializing_if = "Option::is_none")]
     subtarget: Option<LinkTarget>,
-
     /// The text style of sub title.
-    #[serde(skip_serializing_if = "Option::is_none")]
     subtext_style: Option<TextStyle>,
-
     /// The horizontal align of the component.
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_align: Option<TextAlign>,
-
     /// The vertical align of the component.
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_vertical_align: Option<TextVerticalAlign>,
-
     /// Title padding, the unit is px.
-    #[serde(skip_serializing_if = "Option::is_none")]
     padding: Option<Padding>,
-
     /// The gap between the main title and the sub title, the unit is px.
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_gap: Option<f64>,
-
     /// The `zlevel` value of all graphical elements in the title.
-    #[serde(skip_serializing_if = "Option::is_none")]
     zlevel: Option<f64>,
-
     /// The `z` value of all graphical elements in the title.
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
     /// Distance between title component and the left side of the container.
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
     /// Distance between title component and the top side of the container.
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
     /// Distance between title component and the right side of the container.
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
     /// Distance between title component and the bottom side of the container.
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
     /// Background color of title, default to be transparent.
-    #[serde(skip_serializing_if = "Option::is_none")]
     background_color: Option<Color>,
-
     /// Border color of title.
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_color: Option<Color>,
-
     /// Border width of title.
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_width: Option<f64>,
-
     /// Border radius of title.
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_radius: Option<f64>,
-
     /// Shadow color of title.
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_color: Option<Color>,
-
     /// Size of shadow blur.
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_blur: Option<f64>,
-
     /// Offset distance on the horizontal direction of shadow.
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_offset_x: Option<f64>,
-
     /// Offset distance on the vertical direction of shadow.
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_offset_y: Option<f64>,
-}
-
-impl Default for Title {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Title {
-    pub fn new() -> Self {
-        Self {
-            id: None,
-            show: None,
-            text: None,
-            link: None,
-            target: None,
-            text_style: None,
-            subtext: None,
-            sublink: None,
-            subtarget: None,
-            subtext_style: None,
-            text_align: None,
-            text_vertical_align: None,
-            padding: None,
-            item_gap: None,
-            zlevel: None,
-            z: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            background_color: None,
-            border_color: None,
-            border_width: None,
-            border_radius: None,
-            shadow_color: None,
-            shadow_blur: None,
-            shadow_offset_x: None,
-            shadow_offset_y: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn text<S: Into<String>>(mut self, text: S) -> Self {
-        self.text = Some(text.into());
-        self
-    }
-
-    pub fn link<S: Into<String>>(mut self, link: S) -> Self {
-        self.link = Some(link.into());
-        self
-    }
-
-    pub fn target<T: Into<LinkTarget>>(mut self, target: T) -> Self {
-        self.target = Some(target.into());
-        self
-    }
-
-    pub fn text_style<S: Into<TextStyle>>(mut self, text_style: S) -> Self {
-        self.text_style = Some(text_style.into());
-        self
-    }
-
-    pub fn subtext<S: Into<String>>(mut self, subtext: S) -> Self {
-        self.subtext = Some(subtext.into());
-        self
-    }
-
-    pub fn sublink<S: Into<String>>(mut self, sublink: S) -> Self {
-        self.sublink = Some(sublink.into());
-        self
-    }
-
-    pub fn subtarget<T: Into<LinkTarget>>(mut self, subtarget: T) -> Self {
-        self.subtarget = Some(subtarget.into());
-        self
-    }
-
-    pub fn subtext_style<S: Into<TextStyle>>(mut self, subtext_style: S) -> Self {
-        self.subtext_style = Some(subtext_style.into());
-        self
-    }
-
-    pub fn text_align<A: Into<TextAlign>>(mut self, text_align: A) -> Self {
-        self.text_align = Some(text_align.into());
-        self
-    }
-
-    pub fn text_vertical_align<A: Into<TextVerticalAlign>>(
-        mut self,
-        text_vertical_align: A,
-    ) -> Self {
-        self.text_vertical_align = Some(text_vertical_align.into());
-        self
-    }
-
-    pub fn padding<P: Into<Padding>>(mut self, padding: P) -> Self {
-        self.padding = Some(padding.into());
-        self
-    }
-
-    pub fn item_gap<F: Into<f64>>(mut self, item_gap: F) -> Self {
-        self.item_gap = Some(item_gap.into());
-        self
-    }
-
-    pub fn zlevel<F: Into<f64>>(mut self, zlevel: F) -> Self {
-        self.zlevel = Some(zlevel.into());
-        self
-    }
-
-    pub fn z<F: Into<f64>>(mut self, z: F) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
-    pub fn background_color<C: Into<Color>>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.into());
-        self
-    }
-
-    pub fn border_color<C: Into<Color>>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.into());
-        self
-    }
-
-    pub fn border_width<F: Into<f64>>(mut self, border_width: F) -> Self {
-        self.border_width = Some(border_width.into());
-        self
-    }
-
-    pub fn border_radius<F: Into<f64>>(mut self, border_radius: F) -> Self {
-        self.border_radius = Some(border_radius.into());
-        self
-    }
-
-    pub fn shadow_color<C: Into<Color>>(mut self, shadow_color: C) -> Self {
-        self.shadow_color = Some(shadow_color.into());
-        self
-    }
-
-    pub fn shadow_blur<F: Into<f64>>(mut self, shadow_blur: F) -> Self {
-        self.shadow_blur = Some(shadow_blur.into());
-        self
-    }
-
-    pub fn shadow_offset_x<F: Into<f64>>(mut self, shadow_offset_x: F) -> Self {
-        self.shadow_offset_x = Some(shadow_offset_x.into());
-        self
-    }
-
-    pub fn shadow_offset_y<F: Into<f64>>(mut self, shadow_offset_y: F) -> Self {
-        self.shadow_offset_y = Some(shadow_offset_y.into());
-        self
-    }
 }

--- a/charming/src/component/toolbox.rs
+++ b/charming/src/component/toolbox.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{datatype::CompositeValue, element::Orient};
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -10,137 +10,41 @@ pub enum SaveAsImageType {
     Svg,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SaveAsImage {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
     #[serde(rename = "type")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<SaveAsImageType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     background_color: Option<String>,
 }
 
-impl Default for SaveAsImage {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SaveAsImage {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            type_: None,
-            name: None,
-            background_color: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn type_(mut self, type_: SaveAsImageType) -> Self {
-        self.type_ = Some(type_);
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn background_color<S: Into<String>>(mut self, background_color: S) -> Self {
-        self.background_color = Some(background_color.into());
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Restore {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     title: Option<String>,
 }
 
-impl Default for Restore {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Restore {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            title: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn title<S: Into<String>>(mut self, title: S) -> Self {
-        self.title = Some(title.into());
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataView {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     read_only: Option<bool>,
-}
-
-impl Default for DataView {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DataView {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            title: None,
-            read_only: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn title<S: Into<String>>(mut self, title: S) -> Self {
-        self.title = Some(title.into());
-        self
-    }
-
-    pub fn read_only(mut self, read_only: bool) -> Self {
-        self.read_only = Some(read_only);
-        self
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
@@ -165,39 +69,15 @@ impl From<&str> for MagicTypeType {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MagicType {
-    #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<Vec<MagicTypeType>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     title: Option<String>,
-}
-
-impl Default for MagicType {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl MagicType {
-    pub fn new() -> Self {
-        Self {
-            type_: None,
-            title: None,
-        }
-    }
-
-    pub fn type_(mut self, type_: Vec<MagicTypeType>) -> Self {
-        self.type_ = Some(type_);
-        self
-    }
-
-    pub fn title<S: Into<String>>(mut self, title: S) -> Self {
-        self.title = Some(title.into());
-        self
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
@@ -211,205 +91,60 @@ pub enum BrushType {
     Clear,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Brush {
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(rename = "type")]
+    #[charming_set_vec]
     type_: Vec<BrushType>,
 }
 
-impl Default for Brush {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Brush {
-    pub fn new() -> Self {
-        Self { type_: vec![] }
-    }
-
-    pub fn type_(mut self, type_: Vec<BrushType>) -> Self {
-        self.type_ = type_;
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolboxDataZoom {
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_index: Option<CompositeValue>,
 }
 
-impl Default for ToolboxDataZoom {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ToolboxDataZoom {
-    pub fn new() -> Self {
-        Self { y_axis_index: None }
-    }
-
-    pub fn y_axis_index<C: Into<CompositeValue>>(mut self, y_axis_index: C) -> Self {
-        self.y_axis_index = Some(y_axis_index.into());
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Feature {
-    #[serde(skip_serializing_if = "Option::is_none")]
     save_as_image: Option<SaveAsImage>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     restore: Option<Restore>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     data_view: Option<DataView>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     magic_type: Option<MagicType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     data_zoom: Option<ToolboxDataZoom>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     brush: Option<Brush>,
 }
 
-impl Default for Feature {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Feature {
-    pub fn new() -> Self {
-        Self {
-            save_as_image: None,
-            restore: None,
-            data_view: None,
-            magic_type: None,
-            data_zoom: None,
-            brush: None,
-        }
-    }
-
-    pub fn save_as_image(mut self, save_as_image: SaveAsImage) -> Self {
-        self.save_as_image = Some(save_as_image);
-        self
-    }
-
-    pub fn restore(mut self, restore: Restore) -> Self {
-        self.restore = Some(restore);
-        self
-    }
-
-    pub fn data_view(mut self, data_view: DataView) -> Self {
-        self.data_view = Some(data_view);
-        self
-    }
-
-    pub fn magic_type(mut self, magic_type: MagicType) -> Self {
-        self.magic_type = Some(magic_type);
-        self
-    }
-
-    pub fn data_zoom(mut self, data_zoom: ToolboxDataZoom) -> Self {
-        self.data_zoom = Some(data_zoom);
-        self
-    }
-
-    pub fn brush(mut self, brush: Brush) -> Self {
-        self.brush = Some(brush);
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Toolbox {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     feature: Option<Feature>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     orient: Option<Orient>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
 }
 
-impl Default for Toolbox {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Toolbox {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            feature: None,
-            orient: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn feature<T: Into<Feature>>(mut self, feature: T) -> Self {
-        self.feature = Some(feature.into());
-        self
-    }
-
-    pub fn orient<O: Into<Orient>>(mut self, orient: O) -> Self {
-        self.orient = Some(orient.into());
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
     pub fn save_as_image_type(&self) -> Option<&SaveAsImageType> {
         self.feature
             .as_ref()

--- a/charming/src/component/visual_map.rs
+++ b/charming/src/component/visual_map.rs
@@ -1,9 +1,9 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{Color, Orient, TextStyle},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -12,93 +12,21 @@ pub enum VisualMapType {
     Piecewise,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VisualMapPiece {
-    #[serde(skip_serializing_if = "Option::is_none")]
     min: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     lt: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     lte: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     gt: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     gte: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-}
-
-impl Default for VisualMapPiece {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl VisualMapPiece {
-    pub fn new() -> Self {
-        Self {
-            min: None,
-            max: None,
-            lt: None,
-            lte: None,
-            gt: None,
-            gte: None,
-            label: None,
-            color: None,
-        }
-    }
-
-    pub fn min<F: Into<f64>>(mut self, min: F) -> Self {
-        self.min = Some(min.into());
-        self
-    }
-
-    pub fn max<F: Into<f64>>(mut self, max: F) -> Self {
-        self.max = Some(max.into());
-        self
-    }
-
-    pub fn lt<F: Into<f64>>(mut self, lt: F) -> Self {
-        self.lt = Some(lt.into());
-        self
-    }
-
-    pub fn lte<F: Into<f64>>(mut self, lte: F) -> Self {
-        self.lte = Some(lte.into());
-        self
-    }
-
-    pub fn gt<F: Into<f64>>(mut self, gt: F) -> Self {
-        self.gt = Some(gt.into());
-        self
-    }
-
-    pub fn gte<F: Into<f64>>(mut self, gte: F) -> Self {
-        self.gte = Some(gte.into());
-        self
-    }
-
-    pub fn label<S: Into<String>>(mut self, label: S) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
-        self.color = Some(color.into());
-        self
-    }
 }
 
 impl From<(f64, f64)> for VisualMapPiece {
@@ -125,263 +53,57 @@ impl From<(i64, i64, &str)> for VisualMapPiece {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VisualMapChannel {
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     color: Vec<Color>,
 }
 
-impl Default for VisualMapChannel {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl VisualMapChannel {
-    pub fn new() -> Self {
-        Self { color: vec![] }
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: Vec<C>) -> Self {
-        self.color = color.into_iter().map(|c| c.into()).collect();
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VisualMap {
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     type_: Option<VisualMapType>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     color: Vec<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     dimension: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     series_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<f64>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     categories: Vec<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     calculable: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     orient: Option<Orient>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_style: Option<TextStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     range: Option<(f64, f64)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     realtime: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     inverse: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     precision: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_width: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_height: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     in_range: Option<VisualMapChannel>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     out_range: Option<VisualMapChannel>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pieces: Option<Vec<VisualMapPiece>>,
 }
 
-impl Default for VisualMap {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl VisualMap {
-    pub fn new() -> Self {
-        Self {
-            type_: None,
-            color: vec![],
-            show: None,
-            dimension: None,
-            series_index: None,
-            min: None,
-            max: None,
-            categories: vec![],
-            calculable: None,
-            orient: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            text_style: None,
-            range: None,
-            realtime: None,
-            inverse: None,
-            precision: None,
-            item_width: None,
-            item_height: None,
-            in_range: None,
-            out_range: None,
-            pieces: None,
-        }
-    }
-
-    pub fn type_<S: Into<VisualMapType>>(mut self, type_: S) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: Vec<C>) -> Self {
-        self.color = color.into_iter().map(|c| c.into()).collect();
-        self
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn dimension<C: Into<CompositeValue>>(mut self, dimension: C) -> Self {
-        self.dimension = Some(dimension.into());
-        self
-    }
-
-    pub fn series_index<F: Into<f64>>(mut self, series_index: F) -> Self {
-        self.series_index = Some(series_index.into());
-        self
-    }
-
-    pub fn min<F: Into<f64>>(mut self, min: F) -> Self {
-        self.min = Some(min.into());
-        self
-    }
-
-    pub fn max<F: Into<f64>>(mut self, max: F) -> Self {
-        self.max = Some(max.into());
-        self
-    }
-
-    pub fn categories<S: Into<String>>(mut self, categories: Vec<S>) -> Self {
-        self.categories = categories.into_iter().map(|c| c.into()).collect();
-        self
-    }
-
-    pub fn calculable(mut self, calculable: bool) -> Self {
-        self.calculable = Some(calculable);
-        self
-    }
-
-    pub fn orient(mut self, orient: Orient) -> Self {
-        self.orient = Some(orient);
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
-    pub fn text_style<T: Into<TextStyle>>(mut self, text_style: T) -> Self {
-        self.text_style = Some(text_style.into());
-        self
-    }
-
     pub fn range<F: Into<f64>>(mut self, range: (F, F)) -> Self {
         self.range = Some((range.0.into(), range.1.into()));
-        self
-    }
-
-    pub fn realtime(mut self, realtime: bool) -> Self {
-        self.realtime = Some(realtime);
-        self
-    }
-
-    pub fn inverse(mut self, inverse: bool) -> Self {
-        self.inverse = Some(inverse);
-        self
-    }
-
-    pub fn precision<F: Into<f64>>(mut self, precision: F) -> Self {
-        self.precision = Some(precision.into());
-        self
-    }
-
-    pub fn item_width<F: Into<f64>>(mut self, item_width: F) -> Self {
-        self.item_width = Some(item_width.into());
-        self
-    }
-
-    pub fn item_height<F: Into<f64>>(mut self, item_height: F) -> Self {
-        self.item_height = Some(item_height.into());
-        self
-    }
-
-    pub fn in_range<V: Into<VisualMapChannel>>(mut self, in_range: V) -> Self {
-        self.in_range = Some(in_range.into());
-        self
-    }
-
-    pub fn out_range<V: Into<VisualMapChannel>>(mut self, out_range: V) -> Self {
-        self.out_range = Some(out_range.into());
-        self
-    }
-
-    pub fn pieces(mut self, pieces: Vec<VisualMapPiece>) -> Self {
-        self.pieces = Some(pieces);
         self
     }
 }

--- a/charming/src/datatype/dataset.rs
+++ b/charming/src/datatype/dataset.rs
@@ -1,8 +1,7 @@
-use serde::{de::Visitor, ser::SerializeSeq, Deserialize, Deserializer, Serialize};
-
-use crate::element::RawString;
-
 use super::{DataSource, Dimension};
+use crate::element::RawString;
+use charming_macros::CharmingSetters;
+use serde::{de::Visitor, ser::SerializeSeq, Deserialize, Deserializer, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 pub struct Source {
@@ -63,66 +62,18 @@ where
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Transform {
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     transform: Option<RawString>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     from_dataset_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     from_dataset_index: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     from_transform_result: Option<i32>,
-}
-
-impl Default for Transform {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Transform {
-    pub fn new() -> Self {
-        Self {
-            id: None,
-            transform: None,
-            from_dataset_id: None,
-            from_dataset_index: None,
-            from_transform_result: None,
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn transform<R: Into<RawString>>(mut self, transform: R) -> Self {
-        self.transform = Some(transform.into());
-        self
-    }
-
-    pub fn from_dataset_id<S: Into<String>>(mut self, from_dataset_id: S) -> Self {
-        self.from_dataset_id = Some(from_dataset_id.into());
-        self
-    }
-
-    pub fn from_dataset_index<I: Into<i32>>(mut self, from_dataset_index: I) -> Self {
-        self.from_dataset_index = Some(from_dataset_index.into());
-        self
-    }
-
-    pub fn from_transform_result<I: Into<i32>>(mut self, from_transform_result: I) -> Self {
-        self.from_transform_result = Some(from_transform_result.into());
-        self
-    }
 }
 
 impl From<&str> for Transform {

--- a/charming/src/datatype/dimension.rs
+++ b/charming/src/datatype/dimension.rs
@@ -1,3 +1,4 @@
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
@@ -23,49 +24,17 @@ impl From<&str> for DimensionType {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Dimension {
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     type_: Option<DimensionType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     display_name: Option<String>,
-}
-
-impl Default for Dimension {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Dimension {
-    pub fn new() -> Self {
-        Self {
-            type_: None,
-            name: None,
-            display_name: None,
-        }
-    }
-
-    pub fn type_<D: Into<DimensionType>>(mut self, type_: D) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn display_name<S: Into<String>>(mut self, display_name: S) -> Self {
-        self.display_name = Some(display_name.into());
-        self
-    }
 }
 
 impl From<&str> for Dimension {

--- a/charming/src/element/anchor.rs
+++ b/charming/src/element/anchor.rs
@@ -1,83 +1,27 @@
+use super::{icon::Icon, item_style::ItemStyle};
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use super::{icon::Icon, item_style::ItemStyle};
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Anchor {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     show_above: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     size: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     icon: Option<Icon>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     offset_center: Option<(String, String)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     keep_aspect: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
 }
 
-impl Default for Anchor {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Anchor {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            show_above: None,
-            size: None,
-            icon: None,
-            offset_center: None,
-            keep_aspect: None,
-            item_style: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn show_above(mut self, show_above: bool) -> Self {
-        self.show_above = Some(show_above);
-        self
-    }
-
-    pub fn size<F: Into<f64>>(mut self, size: F) -> Self {
-        self.size = Some(size.into());
-        self
-    }
-
-    pub fn icon<S: Into<Icon>>(mut self, icon: S) -> Self {
-        self.icon = Some(icon.into());
-        self
-    }
-
     pub fn offset_center<S: Into<String>>(mut self, offset_center: (S, S)) -> Self {
         self.offset_center = Some((offset_center.0.into(), offset_center.1.into()));
-        self
-    }
-
-    pub fn keep_aspect(mut self, keep_aspect: bool) -> Self {
-        self.keep_aspect = Some(keep_aspect);
-        self
-    }
-
-    pub fn item_style<S: Into<ItemStyle>>(mut self, item_style: S) -> Self {
-        self.item_style = Some(item_style.into());
         self
     }
 }

--- a/charming/src/element/area_style.rs
+++ b/charming/src/element/area_style.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
-
 use super::color::Color;
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -10,46 +10,14 @@ pub enum OriginPosition {
     End,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AreaStyle {
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     origin: Option<OriginPosition>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     opacity: Option<f64>,
-}
-
-impl Default for AreaStyle {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl AreaStyle {
-    pub fn new() -> Self {
-        Self {
-            color: None,
-            origin: None,
-            opacity: None,
-        }
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
-        self.color = Some(color.into());
-        self
-    }
-
-    pub fn origin<O: Into<OriginPosition>>(mut self, origin: O) -> Self {
-        self.origin = Some(origin.into());
-        self
-    }
-
-    pub fn opacity<F: Into<f64>>(mut self, opacity: F) -> Self {
-        self.opacity = Some(opacity.into());
-        self
-    }
 }

--- a/charming/src/element/axis_label.rs
+++ b/charming/src/element/axis_label.rs
@@ -1,107 +1,28 @@
-use serde::{Deserialize, Serialize};
-
-use crate::datatype::CompositeValue;
-
 use super::{
     color::Color,
     font_settings::{FontFamily, FontStyle, FontWeight},
     Formatter,
 };
+use crate::datatype::CompositeValue;
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Default)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisLabel {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     distance: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_style: Option<FontStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_weight: Option<FontWeight>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_family: Option<FontFamily>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_size: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     formatter: Option<Formatter>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     rotate: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     interval: Option<f64>,
-
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     custom_values: Vec<CompositeValue>,
-}
-
-impl AxisLabel {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn distance<F: Into<f64>>(mut self, distance: F) -> Self {
-        self.distance = Some(distance.into());
-        self
-    }
-
-    pub fn font_style<F: Into<FontStyle>>(mut self, font_style: F) -> Self {
-        self.font_style = Some(font_style.into());
-        self
-    }
-
-    pub fn font_weight<F: Into<FontWeight>>(mut self, font_weight: F) -> Self {
-        self.font_weight = Some(font_weight.into());
-        self
-    }
-
-    pub fn font_family<F: Into<FontFamily>>(mut self, font_family: F) -> Self {
-        self.font_family = Some(font_family.into());
-        self
-    }
-
-    pub fn font_size<F: Into<f64>>(mut self, font_size: F) -> Self {
-        self.font_size = Some(font_size.into());
-        self
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
-        self.color = Some(color.into());
-        self
-    }
-
-    pub fn formatter<F: Into<Formatter>>(mut self, formatter: F) -> Self {
-        self.formatter = Some(formatter.into());
-        self
-    }
-
-    pub fn rotate<F: Into<f64>>(mut self, rotate: F) -> Self {
-        self.rotate = Some(rotate.into());
-        self
-    }
-
-    pub fn interval<F: Into<f64>>(mut self, interval: F) -> Self {
-        self.interval = Some(interval.into());
-        self
-    }
-
-    pub fn custom_values<C: Into<CompositeValue>>(mut self, custom_values: Vec<C>) -> Self {
-        self.custom_values = custom_values.into_iter().map(|c| c.into()).collect();
-        self
-    }
 }

--- a/charming/src/element/axis_label.rs
+++ b/charming/src/element/axis_label.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
   Option => #[serde(skip_serializing_if = "Option::is_none")],
   Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
 )]
-#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone, Default)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisLabel {
     show: Option<bool>,

--- a/charming/src/element/axis_line.rs
+++ b/charming/src/element/axis_line.rs
@@ -1,6 +1,6 @@
-use serde::{de::Visitor, ser::SerializeSeq, Deserialize, Deserializer, Serialize};
-
 use super::color::Color;
+use charming_macros::CharmingSetters;
+use serde::{de::Visitor, ser::SerializeSeq, Deserialize, Deserializer, Serialize};
 
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub struct ColorSegment(f64, Color);
@@ -58,83 +58,20 @@ impl From<(f64, Color)> for ColorSegment {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisLineStyle {
     color: Vec<ColorSegment>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_blur: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_offset_x: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_offset_y: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     opacity: Option<f64>,
-}
-
-impl Default for AxisLineStyle {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl AxisLineStyle {
-    pub fn new() -> Self {
-        Self {
-            color: vec![],
-            width: None,
-            shadow_blur: None,
-            shadow_color: None,
-            shadow_offset_x: None,
-            shadow_offset_y: None,
-            opacity: None,
-        }
-    }
-
-    pub fn color<C: Into<ColorSegment>>(mut self, color: C) -> Self {
-        self.color.push(color.into());
-        self
-    }
-
-    pub fn width<F: Into<f64>>(mut self, width: F) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn shadow_blur<F: Into<f64>>(mut self, shadow_blur: F) -> Self {
-        self.shadow_blur = Some(shadow_blur.into());
-        self
-    }
-
-    pub fn shadow_color<C: Into<Color>>(mut self, shadow_color: C) -> Self {
-        self.shadow_color = Some(shadow_color.into());
-        self
-    }
-
-    pub fn shadow_offset_x<F: Into<f64>>(mut self, shadow_offset_x: F) -> Self {
-        self.shadow_offset_x = Some(shadow_offset_x.into());
-        self
-    }
-
-    pub fn shadow_offset_y<F: Into<f64>>(mut self, shadow_offset_y: F) -> Self {
-        self.shadow_offset_y = Some(shadow_offset_y.into());
-        self
-    }
-
-    pub fn opacity<F: Into<f64>>(mut self, opacity: F) -> Self {
-        self.opacity = Some(opacity.into());
-        self
-    }
 }
 
 impl From<(f64, &str)> for AxisLineStyle {
@@ -149,55 +86,15 @@ impl From<(f64, &str, f64)> for AxisLineStyle {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisLine {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     on_zero: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     round_cap: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<AxisLineStyle>,
-}
-
-impl Default for AxisLine {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl AxisLine {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            on_zero: None,
-            round_cap: None,
-            line_style: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn on_zero(mut self, on_zero: bool) -> Self {
-        self.on_zero = Some(on_zero);
-        self
-    }
-
-    pub fn round_cap(mut self, round_cap: bool) -> Self {
-        self.round_cap = Some(round_cap);
-        self
-    }
-
-    pub fn line_style<S: Into<AxisLineStyle>>(mut self, line_style: S) -> Self {
-        self.line_style = Some(line_style.into());
-        self
-    }
 }

--- a/charming/src/element/axis_pointer.rs
+++ b/charming/src/element/axis_pointer.rs
@@ -1,9 +1,9 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{Label, LineStyle},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -23,172 +23,44 @@ pub enum AxisPointerAxis {
     Angle,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisPointerLink {
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis_index: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_index: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_name: Option<String>,
-}
-
-impl Default for AxisPointerLink {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl AxisPointerLink {
-    pub fn new() -> Self {
-        Self {
-            x_axis_index: None,
-            x_axis_name: None,
-            y_axis_index: None,
-            y_axis_name: None,
-        }
-    }
-
-    pub fn x_axis_index<C: Into<CompositeValue>>(mut self, x_axis_index: C) -> Self {
-        self.x_axis_index = Some(x_axis_index.into());
-        self
-    }
-
-    pub fn x_axis_name<S: Into<String>>(mut self, x_axis_name: S) -> Self {
-        self.x_axis_name = Some(x_axis_name.into());
-        self
-    }
-
-    pub fn y_axis_index<C: Into<CompositeValue>>(mut self, y_axis_index: C) -> Self {
-        self.y_axis_index = Some(y_axis_index.into());
-        self
-    }
-
-    pub fn y_axis_name<S: Into<String>>(mut self, y_axis_name: S) -> Self {
-        self.y_axis_name = Some(y_axis_name.into());
-        self
-    }
 }
 
 /// Axis Pointer is a tool for displaying reference line and axis value under
 /// mouse pointer.
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisPointer {
     /// Component ID.
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
     /// Whether to show the axis pointer.
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
     /// Indicator type.
     #[serde(rename = "type")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<AxisPointerType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     snap: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis: Option<AxisPointerAxis>,
-
     /// Label of axis pointer.
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
     /// Line style of axis pointer.
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
-
     /// Axis pointer can be linked to each other.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     link: Vec<AxisPointerLink>,
-}
-
-impl Default for AxisPointer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl AxisPointer {
-    pub fn new() -> Self {
-        Self {
-            id: None,
-            show: None,
-            type_: None,
-            snap: None,
-            animation: None,
-            z: None,
-            axis: None,
-            label: None,
-            line_style: None,
-            link: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn type_<A: Into<AxisPointerType>>(mut self, type_: A) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
-
-    pub fn snap(mut self, snap: bool) -> Self {
-        self.snap = Some(snap);
-        self
-    }
-
-    pub fn animation(mut self, animation: bool) -> Self {
-        self.animation = Some(animation);
-        self
-    }
-
-    pub fn z<F: Into<f64>>(mut self, z: F) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
-    pub fn axis<A: Into<AxisPointerAxis>>(mut self, axis: A) -> Self {
-        self.axis = Some(axis.into());
-        self
-    }
-
-    pub fn label<A: Into<Label>>(mut self, label: A) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn line_style<A: Into<LineStyle>>(mut self, line_style: A) -> Self {
-        self.line_style = Some(line_style.into());
-        self
-    }
-
-    pub fn link<A: Into<AxisPointerLink>>(mut self, link: Vec<A>) -> Self {
-        self.link = link.into_iter().map(|a| a.into()).collect();
-        self
-    }
 }

--- a/charming/src/element/axis_tick.rs
+++ b/charming/src/element/axis_tick.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
   Option => #[serde(skip_serializing_if = "Option::is_none")],
   Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
 )]
-#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone, Default)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisTick {
     show: Option<bool>,

--- a/charming/src/element/axis_tick.rs
+++ b/charming/src/element/axis_tick.rs
@@ -1,63 +1,20 @@
+use super::line_style::LineStyle;
+use crate::datatype::CompositeValue;
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use crate::datatype::CompositeValue;
-
-use super::line_style::LineStyle;
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Default)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisTick {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_number: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     length: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     distance: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
-
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_set_vec]
     custom_values: Vec<CompositeValue>,
-}
-
-impl AxisTick {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn split_number<F: Into<f64>>(mut self, split_number: F) -> Self {
-        self.split_number = Some(split_number.into());
-        self
-    }
-
-    pub fn length<F: Into<f64>>(mut self, length: F) -> Self {
-        self.length = Some(length.into());
-        self
-    }
-
-    pub fn distance<F: Into<f64>>(mut self, distance: F) -> Self {
-        self.distance = Some(distance.into());
-        self
-    }
-
-    pub fn line_style<S: Into<LineStyle>>(mut self, line_style: S) -> Self {
-        self.line_style = Some(line_style.into());
-        self
-    }
-
-    pub fn custom_values<C: Into<CompositeValue>>(mut self, custom_values: Vec<C>) -> Self {
-        self.custom_values = custom_values.into_iter().map(|c| c.into()).collect();
-        self
-    }
 }

--- a/charming/src/element/background.rs
+++ b/charming/src/element/background.rs
@@ -1,109 +1,29 @@
+use super::{area_style::AreaStyle, border_type::BorderType, color::Color, line_style::LineStyle};
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use super::{area_style::AreaStyle, border_type::BorderType, color::Color, line_style::LineStyle};
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BackgroundStyle {
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_width: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_type: Option<BorderType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_radius: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     opacity: Option<f64>,
 }
 
-impl Default for BackgroundStyle {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl BackgroundStyle {
-    pub fn new() -> Self {
-        Self {
-            color: None,
-            border_color: None,
-            border_width: None,
-            border_type: None,
-            border_radius: None,
-            opacity: None,
-        }
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
-        self.color = Some(color.into());
-        self
-    }
-
-    pub fn border_color<C: Into<Color>>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.into());
-        self
-    }
-
-    pub fn border_width<F: Into<f64>>(mut self, border_width: F) -> Self {
-        self.border_width = Some(border_width.into());
-        self
-    }
-
-    pub fn border_type<B: Into<BorderType>>(mut self, border_type: B) -> Self {
-        self.border_type = Some(border_type.into());
-        self
-    }
-
-    pub fn border_radius<F: Into<f64>>(mut self, border_radius: F) -> Self {
-        self.border_radius = Some(border_radius.into());
-        self
-    }
-
-    pub fn opacity<F: Into<f64>>(mut self, opacity: F) -> Self {
-        self.opacity = Some(opacity.into());
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataBackground {
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     area_style: Option<AreaStyle>,
-}
-
-impl Default for DataBackground {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DataBackground {
-    pub fn new() -> Self {
-        Self {
-            line_style: None,
-            area_style: None,
-        }
-    }
-
-    pub fn line_style<L: Into<LineStyle>>(mut self, line_style: L) -> Self {
-        self.line_style = Some(line_style.into());
-        self
-    }
-
-    pub fn area_style<A: Into<AreaStyle>>(mut self, area_style: A) -> Self {
-        self.area_style = Some(area_style.into());
-        self
-    }
 }

--- a/charming/src/element/blur.rs
+++ b/charming/src/element/blur.rs
@@ -1,38 +1,14 @@
+use super::{item_style::ItemStyle, label::Label};
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use super::{item_style::ItemStyle, label::Label};
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Blur {
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-}
-
-impl Default for Blur {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Blur {
-    pub fn new() -> Self {
-        Self {
-            label: None,
-            item_style: None,
-        }
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn item_style<S: Into<ItemStyle>>(mut self, item_style: S) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
 }

--- a/charming/src/element/coordinate_tooltip.rs
+++ b/charming/src/element/coordinate_tooltip.rs
@@ -1,38 +1,24 @@
 #![allow(dead_code)]
 
-use serde::Serialize;
-
-use crate::datatype::CompositeValue;
-
 use super::{Color, Formatter, Padding, TextStyle, Trigger};
+use crate::datatype::CompositeValue;
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CoordinateTooltip {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     trigger: Option<Trigger>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     position: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     formatter: Option<Formatter>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     value_formatter: Option<Formatter>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     background_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     padding: Option<Padding>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     text_style: Option<TextStyle>,
 }

--- a/charming/src/element/dimension_encode.rs
+++ b/charming/src/element/dimension_encode.rs
@@ -1,66 +1,18 @@
+use crate::datatype::CompositeValue;
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use crate::datatype::CompositeValue;
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DimensionEncode {
-    #[serde(skip_serializing_if = "Option::is_none")]
     x: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_name: Option<String>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     tooltip: Vec<CompositeValue>,
-}
-
-impl Default for DimensionEncode {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DimensionEncode {
-    pub fn new() -> Self {
-        Self {
-            x: None,
-            y: None,
-            z: None,
-            item_name: None,
-            tooltip: vec![],
-        }
-    }
-
-    pub fn x<C: Into<CompositeValue>>(mut self, x: C) -> Self {
-        self.x = Some(x.into());
-        self
-    }
-
-    pub fn y<C: Into<CompositeValue>>(mut self, y: C) -> Self {
-        self.y = Some(y.into());
-        self
-    }
-
-    pub fn z<C: Into<CompositeValue>>(mut self, z: C) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
-    pub fn item_name<S: Into<String>>(mut self, item_name: S) -> Self {
-        self.item_name = Some(item_name.into());
-        self
-    }
-
-    pub fn tooltip<S: Into<CompositeValue>>(mut self, tooltip: Vec<S>) -> Self {
-        self.tooltip = tooltip.into_iter().map(|s| s.into()).collect();
-        self
-    }
 }

--- a/charming/src/element/emphasis.rs
+++ b/charming/src/element/emphasis.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
-
 use super::{item_style::ItemStyle, AreaStyle, Label};
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -15,64 +15,16 @@ pub enum EmphasisFocus {
     Adjacency,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Emphasis {
-    #[serde(skip_serializing_if = "Option::is_none")]
     focus: Option<EmphasisFocus>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     area_style: Option<AreaStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     disabled: Option<bool>,
-}
-
-impl Default for Emphasis {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Emphasis {
-    pub fn new() -> Self {
-        Self {
-            focus: None,
-            item_style: None,
-            area_style: None,
-            label: None,
-            disabled: None,
-        }
-    }
-
-    pub fn focus<E: Into<EmphasisFocus>>(mut self, emphasis: E) -> Self {
-        self.focus = Some(emphasis.into());
-        self
-    }
-
-    pub fn item_style<I: Into<ItemStyle>>(mut self, item_style: I) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn area_style<A: Into<AreaStyle>>(mut self, area_style: A) -> Self {
-        self.area_style = Some(area_style.into());
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn disabled(mut self, disabled: bool) -> Self {
-        self.disabled = Some(disabled);
-        self
-    }
 }

--- a/charming/src/element/item_style.rs
+++ b/charming/src/element/item_style.rs
@@ -1,111 +1,24 @@
 use super::{border_type::BorderType, color::Color};
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ItemStyle {
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_width: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_radius: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_type: Option<BorderType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     opacity: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_blur: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_offset_x: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_offset_y: Option<f64>,
-}
-
-impl Default for ItemStyle {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ItemStyle {
-    pub fn new() -> Self {
-        Self {
-            color: None,
-            border_color: None,
-            border_width: None,
-            border_radius: None,
-            border_type: None,
-            opacity: None,
-            shadow_color: None,
-            shadow_blur: None,
-            shadow_offset_x: None,
-            shadow_offset_y: None,
-        }
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
-        self.color = Some(color.into());
-        self
-    }
-
-    pub fn border_color<C: Into<Color>>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.into());
-        self
-    }
-
-    pub fn border_width<F: Into<f64>>(mut self, border_width: F) -> Self {
-        self.border_width = Some(border_width.into());
-        self
-    }
-
-    pub fn border_radius<F: Into<f64>>(mut self, border_radius: F) -> Self {
-        self.border_radius = Some(border_radius.into());
-        self
-    }
-
-    pub fn border_type(mut self, border_type: BorderType) -> Self {
-        self.border_type = Some(border_type);
-        self
-    }
-
-    pub fn opacity<F: Into<f64>>(mut self, opacity: F) -> Self {
-        self.opacity = Some(opacity.into());
-        self
-    }
-
-    pub fn shadow_color<C: Into<Color>>(mut self, shadow_color: C) -> Self {
-        self.shadow_color = Some(shadow_color.into());
-        self
-    }
-
-    pub fn shadow_blur<F: Into<f64>>(mut self, shadow_blur: F) -> Self {
-        self.shadow_blur = Some(shadow_blur.into());
-        self
-    }
-
-    pub fn shadow_offset_x<F: Into<f64>>(mut self, shadow_offset_x: F) -> Self {
-        self.shadow_offset_x = Some(shadow_offset_x.into());
-        self
-    }
-
-    pub fn shadow_offset_y<F: Into<f64>>(mut self, shadow_offset_y: F) -> Self {
-        self.shadow_offset_y = Some(shadow_offset_y.into());
-        self
-    }
 }
 
 impl From<Color> for ItemStyle {

--- a/charming/src/element/label.rs
+++ b/charming/src/element/label.rs
@@ -1,11 +1,11 @@
-use serde::{Deserialize, Serialize};
-
 use super::{
     color::Color,
     font_settings::{FontFamily, FontStyle, FontWeight},
     line_style::LineStyle,
     Formatter,
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
@@ -51,161 +51,43 @@ pub enum LabelVerticalAlign {
     Bottom,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Label {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     position: Option<LabelPosition>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     distance: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     rotate: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     offset: Option<(f64, f64)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     formatter: Option<Formatter>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_style: Option<FontStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_weight: Option<FontWeight>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_family: Option<FontFamily>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_size: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     padding: Option<(f64, f64, f64, f64)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     align: Option<LabelAlign>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     vertical_align: Option<LabelVerticalAlign>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     silent: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     background_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_width: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_blur: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_offset_x: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shadow_offset_y: Option<f64>,
 }
 
-impl Default for Label {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Label {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            position: None,
-            distance: None,
-            rotate: None,
-            offset: None,
-            formatter: None,
-            color: None,
-            font_style: None,
-            font_weight: None,
-            font_family: None,
-            font_size: None,
-            padding: None,
-            align: None,
-            vertical_align: None,
-            silent: None,
-            background_color: None,
-            border_color: None,
-            border_width: None,
-            shadow_blur: None,
-            shadow_offset_x: None,
-            shadow_offset_y: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn position<P: Into<LabelPosition>>(mut self, position: P) -> Self {
-        self.position = Some(position.into());
-        self
-    }
-
-    pub fn distance<F: Into<f64>>(mut self, distance: F) -> Self {
-        self.distance = Some(distance.into());
-        self
-    }
-
-    pub fn rotate<S: Into<String>>(mut self, rotate: S) -> Self {
-        self.rotate = Some(rotate.into());
-        self
-    }
-
     pub fn offset<F: Into<f64>>(mut self, offset: (F, F)) -> Self {
         self.offset = Some((offset.0.into(), offset.1.into()));
         self
     }
-
-    pub fn formatter<F: Into<Formatter>>(mut self, formatter: F) -> Self {
-        self.formatter = Some(formatter.into());
-        self
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
-        self.color = Some(color.into());
-        self
-    }
-
-    pub fn font_style<F: Into<FontStyle>>(mut self, font_style: F) -> Self {
-        self.font_style = Some(font_style.into());
-        self
-    }
-
-    pub fn font_weight<F: Into<FontWeight>>(mut self, font_weight: F) -> Self {
-        self.font_weight = Some(font_weight.into());
-        self
-    }
-
-    pub fn font_family<F: Into<FontFamily>>(mut self, font_family: F) -> Self {
-        self.font_family = Some(font_family.into());
-        self
-    }
-
-    pub fn font_size<F: Into<f64>>(mut self, font_size: F) -> Self {
-        self.font_size = Some(font_size.into());
-        self
-    }
-
     pub fn padding<F: Into<f64>>(mut self, padding: (F, F, F, F)) -> Self {
         self.padding = Some((
             padding.0.into(),
@@ -215,164 +97,31 @@ impl Label {
         ));
         self
     }
-
-    pub fn align<A: Into<LabelAlign>>(mut self, align: A) -> Self {
-        self.align = Some(align.into());
-        self
-    }
-
-    pub fn vertical_align<V: Into<LabelVerticalAlign>>(mut self, vertical_align: V) -> Self {
-        self.vertical_align = Some(vertical_align.into());
-        self
-    }
-
-    pub fn silent(mut self, silent: bool) -> Self {
-        self.silent = Some(silent);
-        self
-    }
-
-    pub fn background_color<C: Into<Color>>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.into());
-        self
-    }
-
-    pub fn border_color<C: Into<Color>>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.into());
-        self
-    }
-
-    pub fn border_width<F: Into<f64>>(mut self, border_width: F) -> Self {
-        self.border_width = Some(border_width.into());
-        self
-    }
-
-    pub fn shadow_blur<F: Into<f64>>(mut self, shadow_blur: F) -> Self {
-        self.shadow_blur = Some(shadow_blur.into());
-        self
-    }
-
-    pub fn shadow_offset_x<F: Into<f64>>(mut self, shadow_offset_x: F) -> Self {
-        self.shadow_offset_x = Some(shadow_offset_x.into());
-        self
-    }
-
-    pub fn shadow_offset_y<F: Into<f64>>(mut self, shadow_offset_y: F) -> Self {
-        self.shadow_offset_y = Some(shadow_offset_y.into());
-        self
-    }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LabelLine {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     show_above: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     length: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     smooth: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min_turn_angle: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
 }
 
-impl Default for LabelLine {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl LabelLine {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            show_above: None,
-            length: None,
-            smooth: None,
-            min_turn_angle: None,
-            line_style: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn show_above(mut self, show_above: bool) -> Self {
-        self.show_above = Some(show_above);
-        self
-    }
-
-    pub fn length<F: Into<f64>>(mut self, length: F) -> Self {
-        self.length = Some(length.into());
-        self
-    }
-
-    pub fn smooth(mut self, smooth: bool) -> Self {
-        self.smooth = Some(smooth);
-        self
-    }
-
-    pub fn min_turn_angle<F: Into<f64>>(mut self, min_turn_angle: F) -> Self {
-        self.min_turn_angle = Some(min_turn_angle.into());
-        self
-    }
-
-    pub fn line_style<S: Into<LineStyle>>(mut self, line_style: S) -> Self {
-        self.line_style = Some(line_style.into());
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LabelLayout {
-    #[serde(skip_serializing_if = "Option::is_none")]
     hide_overlap: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     overlap: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     rotate: Option<f64>,
-}
-
-impl Default for LabelLayout {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl LabelLayout {
-    pub fn new() -> Self {
-        Self {
-            hide_overlap: None,
-            overlap: None,
-            rotate: None,
-        }
-    }
-
-    pub fn hide_overlap(mut self, hide_overlap: bool) -> Self {
-        self.hide_overlap = Some(hide_overlap);
-        self
-    }
-
-    pub fn overlap<S: Into<String>>(mut self, overlap: S) -> Self {
-        self.overlap = Some(overlap.into());
-        self
-    }
-
-    pub fn rotate<F: Into<f64>>(mut self, rotate: F) -> Self {
-        self.rotate = Some(rotate.into());
-        self
-    }
 }

--- a/charming/src/element/line_style.rs
+++ b/charming/src/element/line_style.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
-
 use super::color::Color;
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -10,65 +10,17 @@ pub enum LineStyleType {
     Dotted,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LineStyle {
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     type_: Option<LineStyleType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     opacity: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     curveness: Option<f64>,
-}
-
-impl Default for LineStyle {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl LineStyle {
-    pub fn new() -> Self {
-        Self {
-            color: None,
-            width: None,
-            type_: None,
-            opacity: None,
-            curveness: None,
-        }
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
-        self.color = Some(color.into());
-        self
-    }
-
-    pub fn width<F: Into<f64>>(mut self, width: F) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn type_<L: Into<LineStyleType>>(mut self, type_: L) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
-
-    pub fn opacity<F: Into<f64>>(mut self, opacity: F) -> Self {
-        self.opacity = Some(opacity.into());
-        self
-    }
-
-    pub fn curveness<F: Into<f64>>(mut self, curveness: F) -> Self {
-        self.curveness = Some(curveness.into());
-        self
-    }
 }

--- a/charming/src/element/mark_area.rs
+++ b/charming/src/element/mark_area.rs
@@ -1,117 +1,36 @@
+use super::{blur::Blur, emphasis::Emphasis, item_style::ItemStyle, label::Label};
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use super::{blur::Blur, emphasis::Emphasis, item_style::ItemStyle, label::Label};
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkAreaData {
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis: Option<String>,
 }
 
-impl Default for MarkAreaData {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl MarkAreaData {
-    pub fn new() -> Self {
-        Self {
-            name: None,
-            x_axis: None,
-            y_axis: None,
-        }
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn x_axis<F: Into<String>>(mut self, x_axis: F) -> Self {
-        self.x_axis = Some(x_axis.into());
-        self
-    }
-
-    pub fn y_axis<F: Into<String>>(mut self, y_axis: F) -> Self {
-        self.y_axis = Some(y_axis.into());
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkArea {
-    #[serde(skip_serializing_if = "Option::is_none")]
     silent: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     blur: Option<Blur>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_skip_setter]
     data: Vec<(MarkAreaData, MarkAreaData)>,
 }
 
-impl Default for MarkArea {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl MarkArea {
-    pub fn new() -> Self {
-        Self {
-            silent: None,
-            label: None,
-            item_style: None,
-            emphasis: None,
-            blur: None,
-            data: vec![],
-        }
-    }
-
-    pub fn silent(mut self, silent: bool) -> Self {
-        self.silent = Some(silent);
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn item_style<S: Into<ItemStyle>>(mut self, item_style: S) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
-        self
-    }
-
-    pub fn blur<B: Into<Blur>>(mut self, blur: B) -> Self {
-        self.blur = Some(blur.into());
-        self
-    }
-
     pub fn data<D: Into<MarkAreaData>>(mut self, data: Vec<(D, D)>) -> Self {
         self.data = data
             .into_iter()

--- a/charming/src/element/mark_point.rs
+++ b/charming/src/element/mark_point.rs
@@ -1,3 +1,4 @@
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
@@ -19,67 +20,19 @@ impl From<&str> for MarkPointDataType {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkPointData {
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     type_: Option<MarkPointDataType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<f64>,
-}
-
-impl Default for MarkPointData {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl MarkPointData {
-    pub fn new() -> Self {
-        Self {
-            type_: None,
-            name: None,
-            x_axis: None,
-            y_axis: None,
-            value: None,
-        }
-    }
-
-    pub fn type_<T: Into<MarkPointDataType>>(mut self, type_: T) -> Self {
-        self.type_ = Some(type_.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn x_axis<F: Into<f64>>(mut self, x_axis: F) -> Self {
-        self.x_axis = Some(x_axis.into());
-        self
-    }
-
-    pub fn y_axis<F: Into<f64>>(mut self, y_axis: F) -> Self {
-        self.y_axis = Some(y_axis.into());
-        self
-    }
-
-    pub fn value<F: Into<f64>>(mut self, value: F) -> Self {
-        self.value = Some(value.into());
-        self
-    }
 }
 
 impl From<(&str, &str)> for MarkPointData {
@@ -88,27 +41,13 @@ impl From<(&str, &str)> for MarkPointData {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkPoint {
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<MarkPointData>,
-}
-
-impl Default for MarkPoint {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl MarkPoint {
-    pub fn new() -> Self {
-        Self { data: vec![] }
-    }
-
-    pub fn data<D: Into<MarkPointData>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/element/minor_split_line.rs
+++ b/charming/src/element/minor_split_line.rs
@@ -1,35 +1,14 @@
+use super::line_style::LineStyle;
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use super::line_style::LineStyle;
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MinorSplitLine {
     show: Option<bool>,
     line_style: Option<LineStyle>,
-}
-
-impl Default for MinorSplitLine {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl MinorSplitLine {
-    pub fn new() -> MinorSplitLine {
-        MinorSplitLine {
-            show: None,
-            line_style: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> MinorSplitLine {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn line_style<F: Into<LineStyle>>(mut self, line_style: F) -> MinorSplitLine {
-        self.line_style = Some(line_style.into());
-        self
-    }
 }

--- a/charming/src/element/minor_tick.rs
+++ b/charming/src/element/minor_tick.rs
@@ -1,56 +1,16 @@
+use super::line_style::LineStyle;
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use super::line_style::LineStyle;
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MinorTick {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_number: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     length: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
-}
-
-impl Default for MinorTick {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl MinorTick {
-    pub fn new() -> MinorTick {
-        MinorTick {
-            show: None,
-            split_number: None,
-            length: None,
-            line_style: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> MinorTick {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn split_number<F: Into<f64>>(mut self, split_number: F) -> MinorTick {
-        self.split_number = Some(split_number.into());
-        self
-    }
-
-    pub fn length<F: Into<f64>>(mut self, length: F) -> MinorTick {
-        self.length = Some(length.into());
-        self
-    }
-
-    pub fn line_style<F: Into<LineStyle>>(mut self, line_style: F) -> MinorTick {
-        self.line_style = Some(line_style.into());
-        self
-    }
 }

--- a/charming/src/element/pointer.rs
+++ b/charming/src/element/pointer.rs
@@ -1,92 +1,28 @@
+use super::{icon::Icon, item_style::ItemStyle};
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use super::{icon::Icon, item_style::ItemStyle};
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Pointer {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     show_above: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     icon: Option<Icon>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     offset_center: Option<(String, String)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     length: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     keep_aspect: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
 }
 
-impl Default for Pointer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Pointer {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            show_above: None,
-            icon: None,
-            offset_center: None,
-            length: None,
-            width: None,
-            keep_aspect: None,
-            item_style: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn show_above(mut self, show_above: bool) -> Self {
-        self.show_above = Some(show_above);
-        self
-    }
-
-    pub fn icon<S: Into<Icon>>(mut self, icon: S) -> Self {
-        self.icon = Some(icon.into());
-        self
-    }
-
     pub fn offset_center<S: Into<String>>(mut self, offset_center: (S, S)) -> Self {
         self.offset_center = Some((offset_center.0.into(), offset_center.1.into()));
-        self
-    }
-
-    pub fn length<S: Into<String>>(mut self, length: S) -> Self {
-        self.length = Some(length.into());
-        self
-    }
-
-    pub fn width<F: Into<f64>>(mut self, width: F) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn keep_aspect(mut self, keep_aspect: bool) -> Self {
-        self.keep_aspect = Some(keep_aspect);
-        self
-    }
-
-    pub fn item_style<S: Into<ItemStyle>>(mut self, item_style: S) -> Self {
-        self.item_style = Some(item_style.into());
         self
     }
 }

--- a/charming/src/element/scale_limit.rs
+++ b/charming/src/element/scale_limit.rs
@@ -1,36 +1,13 @@
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ScaleLimit {
-    #[serde(skip_serializing_if = "Option::is_none")]
     min: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<f64>,
-}
-
-impl Default for ScaleLimit {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ScaleLimit {
-    pub fn new() -> Self {
-        Self {
-            min: None,
-            max: None,
-        }
-    }
-
-    pub fn min<F: Into<f64>>(mut self, min: F) -> Self {
-        self.min = Some(min.into());
-        self
-    }
-
-    pub fn max<F: Into<f64>>(mut self, max: F) -> Self {
-        self.max = Some(max.into());
-        self
-    }
 }

--- a/charming/src/element/select.rs
+++ b/charming/src/element/select.rs
@@ -1,47 +1,15 @@
+use super::{item_style::ItemStyle, label::Label};
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use super::{item_style::ItemStyle, label::Label};
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Select {
-    #[serde(skip_serializing_if = "Option::is_none")]
     disabled: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-}
-
-impl Default for Select {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Select {
-    pub fn new() -> Self {
-        Self {
-            disabled: None,
-            label: None,
-            item_style: None,
-        }
-    }
-
-    pub fn disabled(mut self, disabled: bool) -> Self {
-        self.disabled = Some(disabled);
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn item_style<S: Into<ItemStyle>>(mut self, item_style: S) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
 }

--- a/charming/src/element/split_area.rs
+++ b/charming/src/element/split_area.rs
@@ -1,25 +1,12 @@
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SplitArea {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-}
-
-impl Default for SplitArea {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SplitArea {
-    pub fn new() -> Self {
-        Self { show: None }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
 }

--- a/charming/src/element/split_line.rs
+++ b/charming/src/element/split_line.rs
@@ -1,56 +1,16 @@
+use super::line_style::LineStyle;
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use super::line_style::LineStyle;
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SplitLine {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     distance: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     length: Option<f64>,
-}
-
-impl Default for SplitLine {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SplitLine {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            distance: None,
-            line_style: None,
-            length: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn distance<F: Into<f64>>(mut self, distance: F) -> Self {
-        self.distance = Some(distance.into());
-        self
-    }
-
-    pub fn line_style<S: Into<LineStyle>>(mut self, line_style: S) -> Self {
-        self.line_style = Some(line_style.into());
-        self
-    }
-
-    pub fn length<F: Into<f64>>(mut self, length: F) -> Self {
-        self.length = Some(length.into());
-        self
-    }
 }

--- a/charming/src/element/text_style.rs
+++ b/charming/src/element/text_style.rs
@@ -1,93 +1,29 @@
-use serde::{Deserialize, Serialize};
-
 use super::{
     color::Color,
     font_settings::{FontFamily, FontStyle, FontWeight},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TextStyle {
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_style: Option<FontStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_weight: Option<FontWeight>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_family: Option<FontFamily>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_size: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_height: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     align: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     padding: Option<[f64; 4]>,
 }
 
-impl Default for TextStyle {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl TextStyle {
-    pub fn new() -> Self {
-        Self {
-            color: None,
-            font_style: None,
-            font_weight: None,
-            font_family: None,
-            font_size: None,
-            line_height: None,
-            align: None,
-            padding: None,
-        }
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
-        self.color = Some(color.into());
-        self
-    }
-
-    pub fn font_style<F: Into<FontStyle>>(mut self, font_style: F) -> Self {
-        self.font_style = Some(font_style.into());
-        self
-    }
-
-    pub fn font_weight<F: Into<FontWeight>>(mut self, font_weight: F) -> Self {
-        self.font_weight = Some(font_weight.into());
-        self
-    }
-
-    pub fn font_family<F: Into<FontFamily>>(mut self, font_family: F) -> Self {
-        self.font_family = Some(font_family.into());
-        self
-    }
-
-    pub fn font_size<F: Into<f64>>(mut self, font_size: F) -> Self {
-        self.font_size = Some(font_size.into());
-        self
-    }
-
-    pub fn line_height<F: Into<f64>>(mut self, line_height: F) -> Self {
-        self.line_height = Some(line_height.into());
-        self
-    }
-
-    pub fn align<S: Into<String>>(mut self, align: S) -> Self {
-        self.align = Some(align.into());
-        self
-    }
-
     pub fn padding<F: Into<f64> + Copy>(mut self, padding: [F; 4]) -> Self {
         self.padding = Some([
             padding[0].into(),

--- a/charming/src/element/tooltip.rs
+++ b/charming/src/element/tooltip.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
-
 use crate::element::{AxisPointer, Color, Formatter, Padding};
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -21,109 +21,21 @@ pub enum Trigger {
     None,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Tooltip {
-    #[serde(skip_serializing_if = "Option::is_none")]
     trigger: Option<Trigger>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     trigger_on: Option<TriggerOn>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_pointer: Option<AxisPointer>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     formatter: Option<Formatter>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     value_formatter: Option<Formatter>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     position: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     padding: Option<Padding>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     background_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     border_width: Option<f64>,
-}
-
-impl Default for Tooltip {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Tooltip {
-    pub fn new() -> Self {
-        Self {
-            trigger: None,
-            trigger_on: None,
-            axis_pointer: None,
-            formatter: None,
-            value_formatter: None,
-            position: None,
-            padding: None,
-            background_color: None,
-            border_color: None,
-            border_width: None,
-        }
-    }
-
-    pub fn trigger<T: Into<Trigger>>(mut self, trigger: T) -> Self {
-        self.trigger = Some(trigger.into());
-        self
-    }
-
-    pub fn trigger_on<T: Into<TriggerOn>>(mut self, trigger_on: T) -> Self {
-        self.trigger_on = Some(trigger_on.into());
-        self
-    }
-
-    pub fn axis_pointer<A: Into<AxisPointer>>(mut self, axis_pointer: A) -> Self {
-        self.axis_pointer = Some(axis_pointer.into());
-        self
-    }
-
-    pub fn formatter<F: Into<Formatter>>(mut self, formatter: F) -> Self {
-        self.formatter = Some(formatter.into());
-        self
-    }
-
-    pub fn value_formatter<F: Into<Formatter>>(mut self, value_formatter: F) -> Self {
-        self.value_formatter = Some(value_formatter.into());
-        self
-    }
-
-    pub fn position<S: Into<String>>(mut self, position: S) -> Self {
-        self.position = Some(position.into());
-        self
-    }
-
-    pub fn padding<P: Into<Padding>>(mut self, padding: P) -> Self {
-        self.padding = Some(padding.into());
-        self
-    }
-
-    pub fn background_color<C: Into<Color>>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.into());
-        self
-    }
-
-    pub fn border_color<C: Into<Color>>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.into());
-        self
-    }
-
-    pub fn border_width<F: Into<f64>>(mut self, border_width: F) -> Self {
-        self.border_width = Some(border_width.into());
-        self
-    }
 }

--- a/charming/src/lib.rs
+++ b/charming/src/lib.rs
@@ -93,6 +93,7 @@ pub mod theme;
 
 pub use renderer::*;
 
+use charming_macros::CharmingSetters;
 use component::{
     AngleAxis, Aria, Axis, Axis3D, DataZoom, GeoMap, Grid, Grid3D, LegendConfig, ParallelAxis,
     ParallelCoordinate, PolarCoordinate, RadarCoordinate, RadiusAxis, SaveAsImageType, SingleAxis,
@@ -238,372 +239,59 @@ mouse pointer.
 zoom, restore, and reset.
  */
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Chart {
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     title: Vec<Title>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation_duration: Option<AnimationTime>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation_threshold: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation_easing: Option<Easing>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation_delay: Option<AnimationTime>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation_duration_update: Option<AnimationTime>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation_easing_update: Option<Easing>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation_delay_update: Option<AnimationTime>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     legend: Option<LegendConfig>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     toolbox: Option<Toolbox>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     grid: Vec<Grid>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "grid3D")]
     grid3d: Vec<Grid3D>,
-
-    #[serde(default)]
     #[serde_as(as = "OneOrMany<_, PreferOne>")]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     x_axis: Vec<Axis>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "xAxis3D")]
     x_axis3d: Vec<Axis3D>,
-
-    #[serde(default)]
     #[serde_as(as = "OneOrMany<_, PreferOne>")]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     y_axis: Vec<Axis>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "yAxis3D")]
     y_axis3d: Vec<Axis3D>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "zAxis3D")]
     z_axis3d: Vec<Axis3D>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     polar: Vec<PolarCoordinate>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     angle_axis: Vec<AngleAxis>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     radius_axis: Vec<RadiusAxis>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     single_axis: Option<SingleAxis>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     parallel_axis: Vec<ParallelAxis>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     axis_pointer: Vec<AxisPointer>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     visual_map: Vec<VisualMap>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     data_zoom: Vec<DataZoom>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     parallel: Option<ParallelCoordinate>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     dataset: Option<Dataset>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     radar: Vec<RadarCoordinate>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     color: Vec<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     background_color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     mark_line: Option<MarkLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     aria: Option<Aria>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     series: Vec<Series>,
-
-    #[serde(default)]
     #[serde(skip_serializing)]
-    geo_maps: Vec<GeoMap>,
+    geo_map: Vec<GeoMap>,
 }
-
-impl Default for Chart {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Chart {
-    pub fn new() -> Self {
-        Self {
-            title: vec![],
-            animation: None,
-            animation_threshold: None,
-            animation_duration: None,
-            animation_easing: None,
-            animation_delay: None,
-            animation_duration_update: None,
-            animation_easing_update: None,
-            animation_delay_update: None,
-            toolbox: None,
-            legend: None,
-            tooltip: None,
-            grid: vec![],
-            grid3d: vec![],
-            x_axis: vec![],
-            x_axis3d: vec![],
-            y_axis: vec![],
-            y_axis3d: vec![],
-            z_axis3d: vec![],
-            polar: vec![],
-            angle_axis: vec![],
-            radius_axis: vec![],
-            single_axis: None,
-            parallel_axis: vec![],
-            axis_pointer: vec![],
-            visual_map: vec![],
-            data_zoom: vec![],
-            parallel: None,
-            dataset: None,
-            radar: vec![],
-            color: vec![],
-            background_color: None,
-            mark_line: None,
-            aria: None,
-            series: vec![],
-            geo_maps: vec![],
-        }
-    }
-
-    pub fn title(mut self, title: Title) -> Self {
-        self.title.push(title);
-        self
-    }
-
-    pub fn animation(mut self, animation: bool) -> Self {
-        self.animation = Some(animation);
-        self
-    }
-
-    pub fn animation_threshold<F: Into<f64>>(mut self, animation_threshold: F) -> Self {
-        self.animation_threshold = Some(animation_threshold.into());
-        self
-    }
-
-    pub fn animation_duration<A: Into<AnimationTime>>(mut self, animation_time: A) -> Self {
-        self.animation_duration = Some(animation_time.into());
-        self
-    }
-
-    pub fn animation_easing(mut self, easing: Easing) -> Self {
-        self.animation_easing = Some(easing);
-        self
-    }
-
-    pub fn animation_delay<A: Into<AnimationTime>>(mut self, animation_time: A) -> Self {
-        self.animation_delay = Some(animation_time.into());
-        self
-    }
-
-    pub fn animation_duration_update<A: Into<AnimationTime>>(mut self, animation_time: A) -> Self {
-        self.animation_duration_update = Some(animation_time.into());
-        self
-    }
-
-    pub fn animation_easing_update(mut self, easing: Easing) -> Self {
-        self.animation_easing_update = Some(easing);
-        self
-    }
-
-    pub fn animation_delay_update<A: Into<AnimationTime>>(mut self, animation_time: A) -> Self {
-        self.animation_delay_update = Some(animation_time.into());
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
-    pub fn legend<L: Into<LegendConfig>>(mut self, legend: L) -> Self {
-        self.legend = Some(legend.into());
-        self
-    }
-
-    pub fn toolbox(mut self, toolbox: Toolbox) -> Self {
-        self.toolbox = Some(toolbox);
-        self
-    }
-
-    pub fn grid(mut self, grid: Grid) -> Self {
-        self.grid.push(grid);
-        self
-    }
-
-    pub fn grid3d(mut self, grid: Grid3D) -> Self {
-        self.grid3d.push(grid);
-        self
-    }
-
-    pub fn x_axis(mut self, x_axis: Axis) -> Self {
-        self.x_axis.push(x_axis);
-        self
-    }
-
-    pub fn x_axis3d(mut self, x_axis: Axis3D) -> Self {
-        self.x_axis3d.push(x_axis);
-        self
-    }
-
-    pub fn y_axis(mut self, y_axis: Axis) -> Self {
-        self.y_axis.push(y_axis);
-        self
-    }
-
-    pub fn y_axis3d(mut self, y_axis: Axis3D) -> Self {
-        self.y_axis3d.push(y_axis);
-        self
-    }
-
-    pub fn z_axis3d(mut self, z_axis: Axis3D) -> Self {
-        self.z_axis3d.push(z_axis);
-        self
-    }
-
-    pub fn polar(mut self, polar: PolarCoordinate) -> Self {
-        self.polar.push(polar);
-        self
-    }
-
-    pub fn angle_axis(mut self, angle_axis: AngleAxis) -> Self {
-        self.angle_axis.push(angle_axis);
-        self
-    }
-
-    pub fn radius_axis(mut self, radius_axis: RadiusAxis) -> Self {
-        self.radius_axis.push(radius_axis);
-        self
-    }
-
-    pub fn single_axis(mut self, single_axis: SingleAxis) -> Self {
-        self.single_axis = Some(single_axis);
-        self
-    }
-
-    pub fn parallel_axis(mut self, parallel_axis: ParallelAxis) -> Self {
-        self.parallel_axis.push(parallel_axis);
-        self
-    }
-
-    pub fn axis_pointer(mut self, axis_pointer: AxisPointer) -> Self {
-        self.axis_pointer.push(axis_pointer);
-        self
-    }
-
-    pub fn visual_map(mut self, visual_map: VisualMap) -> Self {
-        self.visual_map.push(visual_map);
-        self
-    }
-
-    pub fn data_zoom(mut self, data_zoom: DataZoom) -> Self {
-        self.data_zoom.push(data_zoom);
-        self
-    }
-
-    pub fn parallel(mut self, parallel: ParallelCoordinate) -> Self {
-        self.parallel = Some(parallel);
-        self
-    }
-
-    pub fn dataset(mut self, dataset: Dataset) -> Self {
-        self.dataset = Some(dataset);
-        self
-    }
-
-    pub fn radar(mut self, radar: RadarCoordinate) -> Self {
-        self.radar.push(radar);
-        self
-    }
-
-    pub fn color(mut self, color: Vec<Color>) -> Self {
-        self.color = color;
-        self
-    }
-
-    pub fn background_color<C: Into<Color>>(mut self, color: C) -> Self {
-        self.background_color = Some(color.into());
-        self
-    }
-
-    pub fn mark_line(mut self, mark_line: MarkLine) -> Self {
-        self.mark_line = Some(mark_line);
-        self
-    }
-
-    pub fn aria(mut self, aria: Aria) -> Self {
-        self.aria = Some(aria);
-        self
-    }
-
-    pub fn series<S: Into<Series>>(mut self, series: S) -> Self {
-        self.series.push(series.into());
-        self
-    }
-
-    pub fn geo_map<M: Into<GeoMap>>(mut self, map: M) -> Self {
-        self.geo_maps.push(map.into());
-        self
-    }
-
     pub fn save_as_image_type(&self) -> Option<&SaveAsImageType> {
         self.toolbox
             .as_ref()

--- a/charming/src/series/bar.rs
+++ b/charming/src/series/bar.rs
@@ -1,5 +1,4 @@
-use std::vec;
-
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -10,220 +9,43 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Bar {
     #[serde(rename = "type")]
+    #[charming_type = "bar"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     legend_hover_link: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     polar_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     round_cap: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     realtime_sort: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     show_background: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     background_style: Option<BackgroundStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    emphais: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    emphasis: Option<Emphasis>,
     mark_line: Option<MarkLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     stack: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     sampling: Option<Sampling>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bar_width: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bar_gap: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
 }
 
-impl Default for Bar {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Bar {
-    pub fn new() -> Self {
-        Self {
-            type_: "bar".to_string(),
-            id: None,
-            name: None,
-            color_by: None,
-            legend_hover_link: None,
-            coordinate_system: None,
-            x_axis_index: None,
-            y_axis_index: None,
-            polar_index: None,
-            round_cap: None,
-            realtime_sort: None,
-            show_background: None,
-            background_style: None,
-            label: None,
-            item_style: None,
-            emphais: None,
-            mark_line: None,
-            stack: None,
-            sampling: None,
-            bar_width: None,
-            bar_gap: None,
-            tooltip: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn color_by<C: Into<ColorBy>>(mut self, color_by: C) -> Self {
-        self.color_by = Some(color_by.into());
-        self
-    }
-
-    pub fn legend_hover_link(mut self, legend_hover_link: bool) -> Self {
-        self.legend_hover_link = Some(legend_hover_link);
-        self
-    }
-
-    pub fn coordinate_system<C: Into<CoordinateSystem>>(mut self, coordiate_system: C) -> Self {
-        self.coordinate_system = Some(coordiate_system.into());
-        self
-    }
-
-    pub fn x_axis_index<F: Into<f64>>(mut self, x_axis_index: F) -> Self {
-        self.x_axis_index = Some(x_axis_index.into());
-        self
-    }
-
-    pub fn y_axis_index<F: Into<f64>>(mut self, y_axis_index: F) -> Self {
-        self.y_axis_index = Some(y_axis_index.into());
-        self
-    }
-
-    pub fn polar_index<F: Into<f64>>(mut self, polar_index: F) -> Self {
-        self.polar_index = Some(polar_index.into());
-        self
-    }
-
-    pub fn round_cap(mut self, round_cap: bool) -> Self {
-        self.round_cap = Some(round_cap);
-        self
-    }
-
-    pub fn realtime_sort(mut self, realtime_sort: bool) -> Self {
-        self.realtime_sort = Some(realtime_sort);
-        self
-    }
-
-    pub fn show_background(mut self, show_background: bool) -> Self {
-        self.show_background = Some(show_background);
-        self
-    }
-
-    pub fn background_style<S: Into<BackgroundStyle>>(mut self, background_style: S) -> Self {
-        self.background_style = Some(background_style.into());
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn item_style<S: Into<ItemStyle>>(mut self, item_style: S) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphais = Some(emphasis.into());
-        self
-    }
-
-    pub fn mark_line<M: Into<MarkLine>>(mut self, mark_line: M) -> Self {
-        self.mark_line = Some(mark_line.into());
-        self
-    }
-
-    pub fn stack<S: Into<String>>(mut self, stack: S) -> Self {
-        self.stack = Some(stack.into());
-        self
-    }
-
-    pub fn sampling(mut self, sampling: Sampling) -> Self {
-        self.sampling = Some(sampling);
-        self
-    }
-
-    pub fn bar_width<C: Into<CompositeValue>>(mut self, bar_width: C) -> Self {
-        self.bar_width = Some(bar_width.into());
-        self
-    }
-
-    pub fn bar_gap<C: Into<CompositeValue>>(mut self, bar_gap: C) -> Self {
-        self.bar_gap = Some(bar_gap.into());
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
     pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
         self.data = data.into_iter().map(|d| d.into()).collect();
         self

--- a/charming/src/series/bar.rs
+++ b/charming/src/series/bar.rs
@@ -41,13 +41,5 @@ pub struct Bar {
     bar_gap: Option<CompositeValue>,
     tooltip: Option<Tooltip>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
     data: DataFrame,
-}
-
-impl Bar {
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/bar3d.rs
+++ b/charming/src/series/bar3d.rs
@@ -1,96 +1,32 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::{CompositeValue, DataFrame, DataPoint},
     element::{CoordinateSystem, DimensionEncode},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 pub struct Bar3d {
     #[serde(rename = "type")]
+    #[charming_type = "bar3D"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     grid3d_index: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     geo3d_index: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     globe_index: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     shading: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     encode: Option<DimensionEncode>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
-}
-impl Default for Bar3d {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl Bar3d {
-    pub fn new() -> Self {
-        Self {
-            type_: "bar3D".to_string(),
-            name: None,
-            coordinate_system: None,
-            grid3d_index: None,
-            geo3d_index: None,
-            globe_index: None,
-            shading: None,
-            encode: None,
-            data: DataFrame::new(),
-        }
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn coordinate_system<C: Into<CoordinateSystem>>(mut self, coordinate_system: C) -> Self {
-        self.coordinate_system = Some(coordinate_system.into());
-        self
-    }
-
-    pub fn grid3d_index<C: Into<CompositeValue>>(mut self, grid3d_index: C) -> Self {
-        self.grid3d_index = Some(grid3d_index.into());
-        self
-    }
-
-    pub fn geo3d_index<C: Into<CompositeValue>>(mut self, geo3d_index: C) -> Self {
-        self.geo3d_index = Some(geo3d_index.into());
-        self
-    }
-
-    pub fn globe_index<C: Into<CompositeValue>>(mut self, globe_index: C) -> Self {
-        self.globe_index = Some(globe_index.into());
-        self
-    }
-
-    pub fn shading<S: Into<String>>(mut self, shading: S) -> Self {
-        self.shading = Some(shading.into());
-        self
-    }
-
-    pub fn encode<D: Into<DimensionEncode>>(mut self, encode: D) -> Self {
-        self.encode = Some(encode.into());
-        self
-    }
-
     pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
         self.data = data.into_iter().map(|d| d.into()).collect();
         self

--- a/charming/src/series/bar3d.rs
+++ b/charming/src/series/bar3d.rs
@@ -22,13 +22,5 @@ pub struct Bar3d {
     shading: Option<String>,
     encode: Option<DimensionEncode>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
     data: DataFrame,
-}
-
-impl Bar3d {
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/boxplot.rs
+++ b/charming/src/series/boxplot.rs
@@ -26,13 +26,5 @@ pub struct Boxplot {
     item_style: Option<ItemStyle>,
     z: Option<usize>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
     data: DataFrame,
-}
-
-impl Boxplot {
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/boxplot.rs
+++ b/charming/src/series/boxplot.rs
@@ -1,127 +1,38 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{ColorBy, CoordinateSystem, ItemStyle, Tooltip},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Boxplot {
     #[serde(rename = "type")]
+    #[charming_type = "boxplot"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     legend_hover_link: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     hover_animation: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    dataset_index: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    dataset_index: Option<f64>,
     tooltip: Option<Tooltip>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<usize>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
 }
 
-impl Default for Boxplot {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Boxplot {
-    pub fn new() -> Self {
-        Boxplot {
-            type_: String::from("boxplot"),
-            id: None,
-            name: None,
-            coordinate_system: None,
-            color_by: None,
-            legend_hover_link: None,
-            hover_animation: None,
-            dataset_index: None,
-            tooltip: None,
-            data: vec![],
-            item_style: None,
-            z: None,
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn coordinate_system<C: Into<CoordinateSystem>>(mut self, coordinate_system: C) -> Self {
-        self.coordinate_system = Some(coordinate_system.into());
-        self
-    }
-
-    pub fn color_by<C: Into<ColorBy>>(mut self, color_by: C) -> Self {
-        self.color_by = Some(color_by.into());
-        self
-    }
-
-    pub fn legend_hover_link(mut self, legend_hover_link: bool) -> Self {
-        self.legend_hover_link = Some(legend_hover_link);
-        self
-    }
-
-    pub fn hover_animation(mut self, hover_animation: bool) -> Self {
-        self.hover_animation = Some(hover_animation);
-        self
-    }
-
-    pub fn dataset_index(mut self, dataset_index: u64) -> Self {
-        self.dataset_index = Some(dataset_index);
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
-    pub fn item_style<S: Into<ItemStyle>>(mut self, item_style: S) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
     pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
         self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
-
-    pub fn z(mut self, z: usize) -> Self {
-        self.z = Some(z);
         self
     }
 }

--- a/charming/src/series/candlestick.rs
+++ b/charming/src/series/candlestick.rs
@@ -1,89 +1,31 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{ColorBy, CoordinateSystem, Tooltip},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Candlestick {
     #[serde(rename = "type")]
+    #[charming_type = "candlestick"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordiate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     legend_hover_link: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
 }
-
-impl Default for Candlestick {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Candlestick {
-    pub fn new() -> Self {
-        Self {
-            type_: "candlestick".to_string(),
-            id: None,
-            name: None,
-            coordiate_system: None,
-            color_by: None,
-            legend_hover_link: None,
-            data: vec![],
-            tooltip: None,
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn coordiate_system<C: Into<CoordinateSystem>>(mut self, coordiate_system: C) -> Self {
-        self.coordiate_system = Some(coordiate_system.into());
-        self
-    }
-
-    pub fn color_by(mut self, color_by: ColorBy) -> Self {
-        self.color_by = Some(color_by);
-        self
-    }
-
-    pub fn legend_hover_link(mut self, legend_hover_link: bool) -> Self {
-        self.legend_hover_link = Some(legend_hover_link);
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
     pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
         self.data = data.into_iter().map(|d| d.into()).collect();
         self

--- a/charming/src/series/candlestick.rs
+++ b/charming/src/series/candlestick.rs
@@ -22,12 +22,5 @@ pub struct Candlestick {
     legend_hover_link: Option<bool>,
     tooltip: Option<Tooltip>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
     data: DataFrame,
-}
-impl Candlestick {
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/custom.rs
+++ b/charming/src/series/custom.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::{CompositeValue, DataFrame, DataPoint, Dimension},
     element::{
@@ -7,194 +5,44 @@ use crate::{
         Tooltip,
     },
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Custom {
+    #[serde(rename = "type")]
+    #[charming_type = "custom"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     legend_hover_link: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis_index: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_index: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     polar_index: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     geo_index: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     calendar_index: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     render_item: Option<RawString>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label_line: Option<LabelLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label_layout: Option<LabelLayout>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     selected_mode: Option<bool>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     dimensions: Vec<Dimension>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     encode: Option<DimensionEncode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
 }
 
-impl Default for Custom {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Custom {
-    pub fn new() -> Self {
-        Self {
-            type_: "custom".to_string(),
-            id: None,
-            name: None,
-            color_by: None,
-            legend_hover_link: None,
-            coordinate_system: None,
-            x_axis_index: None,
-            y_axis_index: None,
-            polar_index: None,
-            geo_index: None,
-            calendar_index: None,
-            render_item: None,
-            item_style: None,
-            label_line: None,
-            label_layout: None,
-            selected_mode: None,
-            dimensions: vec![],
-            encode: None,
-            tooltip: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn color_by<C: Into<ColorBy>>(mut self, color_by: C) -> Self {
-        self.color_by = Some(color_by.into());
-        self
-    }
-
-    pub fn legend_hover_link(mut self, legend_hover_link: bool) -> Self {
-        self.legend_hover_link = Some(legend_hover_link);
-        self
-    }
-
-    pub fn coordinate_system<C: Into<CoordinateSystem>>(mut self, coordinate_system: C) -> Self {
-        self.coordinate_system = Some(coordinate_system.into());
-        self
-    }
-
-    pub fn x_axis_index<C: Into<CompositeValue>>(mut self, x_axis_index: C) -> Self {
-        self.x_axis_index = Some(x_axis_index.into());
-        self
-    }
-
-    pub fn y_axis_index<C: Into<CompositeValue>>(mut self, y_axis_index: C) -> Self {
-        self.y_axis_index = Some(y_axis_index.into());
-        self
-    }
-
-    pub fn polar_index<C: Into<CompositeValue>>(mut self, polar_index: C) -> Self {
-        self.polar_index = Some(polar_index.into());
-        self
-    }
-
-    pub fn geo_index<C: Into<CompositeValue>>(mut self, geo_index: C) -> Self {
-        self.geo_index = Some(geo_index.into());
-        self
-    }
-
-    pub fn calendar_index<C: Into<CompositeValue>>(mut self, calendar_index: C) -> Self {
-        self.calendar_index = Some(calendar_index.into());
-        self
-    }
-
-    pub fn render_item<R: Into<RawString>>(mut self, render_item: R) -> Self {
-        self.render_item = Some(render_item.into());
-        self
-    }
-
-    pub fn item_style<I: Into<ItemStyle>>(mut self, item_style: I) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn label_line<L: Into<LabelLine>>(mut self, label_line: L) -> Self {
-        self.label_line = Some(label_line.into());
-        self
-    }
-
-    pub fn label_layout<L: Into<LabelLayout>>(mut self, label_layout: L) -> Self {
-        self.label_layout = Some(label_layout.into());
-        self
-    }
-
-    pub fn selected_mode(mut self, selected_mode: bool) -> Self {
-        self.selected_mode = Some(selected_mode);
-        self
-    }
-
-    pub fn dimensions<D: Into<Dimension>>(mut self, dimensions: Vec<D>) -> Self {
-        self.dimensions = dimensions.into_iter().map(|d| d.into()).collect();
-        self
-    }
-
-    pub fn encode<E: Into<DimensionEncode>>(mut self, encode: E) -> Self {
-        self.encode = Some(encode.into());
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
     pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
         self.data = data.into_iter().map(|d| d.into()).collect();
         self

--- a/charming/src/series/custom.rs
+++ b/charming/src/series/custom.rs
@@ -38,13 +38,5 @@ pub struct Custom {
     encode: Option<DimensionEncode>,
     tooltip: Option<Tooltip>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
     data: DataFrame,
-}
-
-impl Custom {
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/effect_scatter.rs
+++ b/charming/src/series/effect_scatter.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{
@@ -7,6 +5,8 @@ use crate::{
         Symbol, Tooltip,
     },
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -28,300 +28,59 @@ pub enum RippleEffectBrushType {
     Stroke,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RippleEffect {
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     number: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     period: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     scale: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     brush_type: Option<RippleEffectBrushType>,
 }
 
-impl Default for RippleEffect {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl RippleEffect {
-    pub fn new() -> Self {
-        Self {
-            color: None,
-            number: None,
-            period: None,
-            scale: None,
-            brush_type: None,
-        }
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
-        self.color = Some(color.into());
-        self
-    }
-
-    pub fn number<F: Into<f64>>(mut self, number: F) -> Self {
-        self.number = Some(number.into());
-        self
-    }
-
-    pub fn period<F: Into<f64>>(mut self, period: F) -> Self {
-        self.period = Some(period.into());
-        self
-    }
-
-    pub fn scale<F: Into<f64>>(mut self, scale: F) -> Self {
-        self.scale = Some(scale.into());
-        self
-    }
-
-    pub fn brush_type<B: Into<RippleEffectBrushType>>(mut self, brush_type: B) -> Self {
-        self.brush_type = Some(brush_type.into());
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EffectScatter {
     #[serde(rename = "type")]
+    #[charming_type = "effectScatter"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     legend_hover_link: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     effect_type: Option<EffectType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     show_effect_on: Option<ShowEffectOn>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     polar_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     geo_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     calendar_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol: Option<Symbol>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_size: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_rotate: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_keep_aspect: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_offset: Option<(String, String)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label_line: Option<LabelLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label_layout: Option<LabelLayout>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
 }
 
-impl Default for EffectScatter {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl EffectScatter {
-    pub fn new() -> Self {
-        Self {
-            type_: "effectScatter".to_string(),
-            id: None,
-            name: None,
-            color_by: None,
-            legend_hover_link: None,
-            effect_type: None,
-            show_effect_on: None,
-            coordinate_system: None,
-            x_axis_index: None,
-            y_axis_index: None,
-            polar_index: None,
-            geo_index: None,
-            calendar_index: None,
-            symbol: None,
-            symbol_size: None,
-            symbol_rotate: None,
-            symbol_keep_aspect: None,
-            symbol_offset: None,
-            label: None,
-            label_line: None,
-            label_layout: None,
-            item_style: None,
-            emphasis: None,
-            tooltip: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn color_by<C: Into<ColorBy>>(mut self, color_by: C) -> Self {
-        self.color_by = Some(color_by.into());
-        self
-    }
-
-    pub fn legend_hover_link(mut self, legend_hover_link: bool) -> Self {
-        self.legend_hover_link = Some(legend_hover_link);
-        self
-    }
-
-    pub fn effect_type<E: Into<EffectType>>(mut self, effect_type: E) -> Self {
-        self.effect_type = Some(effect_type.into());
-        self
-    }
-
-    pub fn show_effect_on<S: Into<ShowEffectOn>>(mut self, show_effect_on: S) -> Self {
-        self.show_effect_on = Some(show_effect_on.into());
-        self
-    }
-
-    pub fn coordinate_system<C: Into<CoordinateSystem>>(mut self, coordinate_system: C) -> Self {
-        self.coordinate_system = Some(coordinate_system.into());
-        self
-    }
-
-    pub fn x_axis_index<F: Into<f64>>(mut self, x_axis_index: F) -> Self {
-        self.x_axis_index = Some(x_axis_index.into());
-        self
-    }
-
-    pub fn y_axis_index<F: Into<f64>>(mut self, y_axis_index: F) -> Self {
-        self.y_axis_index = Some(y_axis_index.into());
-        self
-    }
-
-    pub fn polar_index<F: Into<f64>>(mut self, polar_index: F) -> Self {
-        self.polar_index = Some(polar_index.into());
-        self
-    }
-
-    pub fn geo_index<F: Into<f64>>(mut self, geo_index: F) -> Self {
-        self.geo_index = Some(geo_index.into());
-        self
-    }
-
-    pub fn calendar_index<F: Into<f64>>(mut self, calendar_index: F) -> Self {
-        self.calendar_index = Some(calendar_index.into());
-        self
-    }
-
-    pub fn symbol<S: Into<Symbol>>(mut self, symbol: S) -> Self {
-        self.symbol = Some(symbol.into());
-        self
-    }
-
-    pub fn symbol_size<F: Into<f64>>(mut self, symbol_size: F) -> Self {
-        self.symbol_size = Some(symbol_size.into());
-        self
-    }
-
-    pub fn symbol_rotate<F: Into<f64>>(mut self, symbol_rotate: F) -> Self {
-        self.symbol_rotate = Some(symbol_rotate.into());
-        self
-    }
-
-    pub fn symbol_keep_aspect(mut self, symbol_keep_aspect: bool) -> Self {
-        self.symbol_keep_aspect = Some(symbol_keep_aspect);
-        self
-    }
-
-    pub fn symbol_offset<S: Into<String>>(mut self, symbol_offset: (S, S)) -> Self {
-        self.symbol_offset = Some((symbol_offset.0.into(), symbol_offset.1.into()));
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn label_line<L: Into<LabelLine>>(mut self, label_line: L) -> Self {
-        self.label_line = Some(label_line.into());
-        self
-    }
-
-    pub fn label_layout<L: Into<LabelLayout>>(mut self, label_layout: L) -> Self {
-        self.label_layout = Some(label_layout.into());
-        self
-    }
-
-    pub fn item_style<I: Into<ItemStyle>>(mut self, item_style: I) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
     pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
         self.data = data.into_iter().map(|d| d.into()).collect();
         self

--- a/charming/src/series/effect_scatter.rs
+++ b/charming/src/series/effect_scatter.rs
@@ -76,13 +76,5 @@ pub struct EffectScatter {
     emphasis: Option<Emphasis>,
     tooltip: Option<Tooltip>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
     data: DataFrame,
-}
-
-impl EffectScatter {
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/funnel.rs
+++ b/charming/src/series/funnel.rs
@@ -47,13 +47,5 @@ pub struct Funnel {
     emphasis: Option<Emphasis>,
     tooltip: Option<Tooltip>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
     data: DataFrame,
-}
-
-impl Funnel {
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/funnel.rs
+++ b/charming/src/series/funnel.rs
@@ -1,9 +1,9 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::{CompositeValue, DataFrame, DataPoint},
     element::{ColorBy, Emphasis, ItemStyle, Label, LabelLine, Orient, Sort, Tooltip},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -13,238 +13,45 @@ pub enum Align {
     Center,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Funnel {
     #[serde(rename = "type")]
+    #[charming_type = "funnel"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min_size: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_size: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     orient: Option<Orient>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     sort: Option<Sort>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     gap: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     legend_hover_link: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     funnel_align: Option<Align>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label_line: Option<LabelLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
 }
 
-impl Default for Funnel {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Funnel {
-    pub fn new() -> Self {
-        Self {
-            type_: "funnel".to_string(),
-            id: None,
-            name: None,
-            color_by: None,
-            min: None,
-            max: None,
-            min_size: None,
-            max_size: None,
-            width: None,
-            height: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            orient: None,
-            sort: None,
-            gap: None,
-            legend_hover_link: None,
-            funnel_align: None,
-            label: None,
-            label_line: None,
-            item_style: None,
-            emphasis: None,
-            tooltip: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn color_by(mut self, color_by: ColorBy) -> Self {
-        self.color_by = Some(color_by);
-        self
-    }
-
-    pub fn min<F: Into<f64>>(mut self, min: F) -> Self {
-        self.min = Some(min.into());
-        self
-    }
-
-    pub fn max<F: Into<f64>>(mut self, max: F) -> Self {
-        self.max = Some(max.into());
-        self
-    }
-
-    pub fn min_size<S: Into<String>>(mut self, min_size: S) -> Self {
-        self.min_size = Some(min_size.into());
-        self
-    }
-
-    pub fn max_size<S: Into<String>>(mut self, max_size: S) -> Self {
-        self.max_size = Some(max_size.into());
-        self
-    }
-
-    pub fn width<C: Into<CompositeValue>>(mut self, width: C) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn height<C: Into<CompositeValue>>(mut self, height: C) -> Self {
-        self.height = Some(height.into());
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
-    pub fn orient<O: Into<Orient>>(mut self, orient: O) -> Self {
-        self.orient = Some(orient.into());
-        self
-    }
-
-    pub fn sort<S: Into<Sort>>(mut self, sort: S) -> Self {
-        self.sort = Some(sort.into());
-        self
-    }
-
-    pub fn gap<F: Into<f64>>(mut self, gap: F) -> Self {
-        self.gap = Some(gap.into());
-        self
-    }
-
-    pub fn legend_hover_link(mut self, legend_hover_link: bool) -> Self {
-        self.legend_hover_link = Some(legend_hover_link);
-        self
-    }
-
-    pub fn funnel_align<A: Into<Align>>(mut self, funnel_align: A) -> Self {
-        self.funnel_align = Some(funnel_align.into());
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn label_line<L: Into<LabelLine>>(mut self, label_line: L) -> Self {
-        self.label_line = Some(label_line.into());
-        self
-    }
-
-    pub fn item_style<I: Into<ItemStyle>>(mut self, item_style: I) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
     pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
         self.data = data.into_iter().map(|d| d.into()).collect();
         self

--- a/charming/src/series/gauge.rs
+++ b/charming/src/series/gauge.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{
@@ -8,449 +6,104 @@ use crate::{
         SplitLine, Tooltip,
     },
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GaugeDetail {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Color>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_style: Option<FontStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_weight: Option<FontWeight>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_family: Option<FontFamily>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     font_size: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     precision: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     value_animation: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     formatter: Option<Formatter>,
 }
 
-impl Default for GaugeDetail {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl GaugeDetail {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            color: None,
-            font_style: None,
-            font_weight: None,
-            font_family: None,
-            font_size: None,
-            precision: None,
-            value_animation: None,
-            formatter: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
-        self.color = Some(color.into());
-        self
-    }
-
-    pub fn font_style<F: Into<FontStyle>>(mut self, font_style: F) -> Self {
-        self.font_style = Some(font_style.into());
-        self
-    }
-
-    pub fn font_weight<F: Into<FontWeight>>(mut self, font_weight: F) -> Self {
-        self.font_weight = Some(font_weight.into());
-        self
-    }
-
-    pub fn font_family<F: Into<FontFamily>>(mut self, font_family: F) -> Self {
-        self.font_family = Some(font_family.into());
-        self
-    }
-
-    pub fn font_size<F: Into<f64>>(mut self, font_size: F) -> Self {
-        self.font_size = Some(font_size.into());
-        self
-    }
-
-    pub fn precision<F: Into<f64>>(mut self, precision: F) -> Self {
-        self.precision = Some(precision.into());
-        self
-    }
-
-    pub fn value_animation(mut self, value_animation: bool) -> Self {
-        self.value_animation = Some(value_animation);
-        self
-    }
-
-    pub fn formatter<F: Into<Formatter>>(mut self, formatter: F) -> Self {
-        self.formatter = Some(formatter.into());
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GaugeTitle {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     offset_center: Option<(String, String)>,
 }
 
-impl Default for GaugeTitle {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl GaugeTitle {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            offset_center: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
     pub fn offset_center<S: Into<String>>(mut self, offset_center: (S, S)) -> Self {
         self.offset_center = Some((offset_center.0.into(), offset_center.1.into()));
         self
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GaugeProgress {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     overlap: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     round_cap: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     clip: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
 }
 
-impl Default for GaugeProgress {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl GaugeProgress {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            overlap: None,
-            width: None,
-            round_cap: None,
-            clip: None,
-            item_style: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn overlap(mut self, overlap: bool) -> Self {
-        self.overlap = Some(overlap);
-        self
-    }
-
-    pub fn width<F: Into<f64>>(mut self, width: F) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn round_cap(mut self, round_cap: bool) -> Self {
-        self.round_cap = Some(round_cap);
-        self
-    }
-
-    pub fn clip(mut self, clip: bool) -> Self {
-        self.clip = Some(clip);
-        self
-    }
-
-    pub fn item_style(mut self, item_style: ItemStyle) -> Self {
-        self.item_style = Some(item_style);
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Gauge {
     #[serde(rename = "type")]
+    #[charming_type = "gauge"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     zlevel: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     center: Option<(String, String)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     legend_hover_link: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     start_angle: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     end_angle: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     clockwise: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_number: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     radius: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     progress: Option<GaugeProgress>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_line: Option<AxisLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_tick: Option<AxisTick>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     axis_label: Option<AxisLabel>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     split_line: Option<SplitLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pointer: Option<Pointer>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     anchor: Option<Anchor>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     detail: Option<GaugeDetail>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     title: Option<GaugeTitle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
 }
 
-impl Default for Gauge {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Gauge {
-    pub fn new() -> Self {
-        Self {
-            type_: "gauge".to_string(),
-            id: None,
-            name: None,
-            color_by: None,
-            zlevel: None,
-            z: None,
-            center: None,
-            legend_hover_link: None,
-            start_angle: None,
-            end_angle: None,
-            clockwise: None,
-            min: None,
-            max: None,
-            split_number: None,
-            radius: None,
-            progress: None,
-            axis_line: None,
-            axis_tick: None,
-            axis_label: None,
-            split_line: None,
-            pointer: None,
-            anchor: None,
-            detail: None,
-            title: None,
-            tooltip: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn color_by<C: Into<ColorBy>>(mut self, color_by: C) -> Self {
-        self.color_by = Some(color_by.into());
-        self
-    }
-
-    pub fn zlevel<F: Into<f64>>(mut self, zlevel: F) -> Self {
-        self.zlevel = Some(zlevel.into());
-        self
-    }
-
-    pub fn z<F: Into<f64>>(mut self, z: F) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
     pub fn center<S: Into<String>>(mut self, center: (S, S)) -> Self {
         self.center = Some((center.0.into(), center.1.into()));
-        self
-    }
-
-    pub fn legend_hover_link(mut self, legend_hover_link: bool) -> Self {
-        self.legend_hover_link = Some(legend_hover_link);
-        self
-    }
-
-    pub fn start_angle<F: Into<f64>>(mut self, start_angle: F) -> Self {
-        self.start_angle = Some(start_angle.into());
-        self
-    }
-
-    pub fn end_angle<F: Into<f64>>(mut self, end_angle: F) -> Self {
-        self.end_angle = Some(end_angle.into());
-        self
-    }
-
-    pub fn clockwise(mut self, clockwise: bool) -> Self {
-        self.clockwise = Some(clockwise);
-        self
-    }
-
-    pub fn min<F: Into<f64>>(mut self, min: F) -> Self {
-        self.min = Some(min.into());
-        self
-    }
-
-    pub fn max<F: Into<f64>>(mut self, max: F) -> Self {
-        self.max = Some(max.into());
-        self
-    }
-
-    pub fn split_number<F: Into<f64>>(mut self, split_number: F) -> Self {
-        self.split_number = Some(split_number.into());
-        self
-    }
-
-    pub fn radius<S: Into<String>>(mut self, radius: S) -> Self {
-        self.radius = Some(radius.into());
-        self
-    }
-
-    pub fn progress<P: Into<GaugeProgress>>(mut self, progress: P) -> Self {
-        self.progress = Some(progress.into());
-        self
-    }
-
-    pub fn axis_line<L: Into<AxisLine>>(mut self, axis_line: L) -> Self {
-        self.axis_line = Some(axis_line.into());
-        self
-    }
-
-    pub fn axis_tick<T: Into<AxisTick>>(mut self, axis_tick: T) -> Self {
-        self.axis_tick = Some(axis_tick.into());
-        self
-    }
-
-    pub fn axis_label<L: Into<AxisLabel>>(mut self, axis_label: L) -> Self {
-        self.axis_label = Some(axis_label.into());
-        self
-    }
-
-    pub fn split_line<L: Into<SplitLine>>(mut self, split_line: L) -> Self {
-        self.split_line = Some(split_line.into());
-        self
-    }
-
-    pub fn pointer<P: Into<Pointer>>(mut self, pointer: P) -> Self {
-        self.pointer = Some(pointer.into());
-        self
-    }
-
-    pub fn anchor<A: Into<Anchor>>(mut self, anchor: A) -> Self {
-        self.anchor = Some(anchor.into());
-        self
-    }
-
-    pub fn detail<D: Into<GaugeDetail>>(mut self, detail: D) -> Self {
-        self.detail = Some(detail.into());
-        self
-    }
-
-    pub fn title<T: Into<GaugeTitle>>(mut self, title: T) -> Self {
-        self.title = Some(title.into());
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
         self
     }
 

--- a/charming/src/series/gauge.rs
+++ b/charming/src/series/gauge.rs
@@ -97,18 +97,12 @@ pub struct Gauge {
     title: Option<GaugeTitle>,
     tooltip: Option<Tooltip>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
     data: DataFrame,
 }
 
 impl Gauge {
     pub fn center<S: Into<String>>(mut self, center: (S, S)) -> Self {
         self.center = Some((center.0.into(), center.1.into()));
-        self
-    }
-
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
         self
     }
 }

--- a/charming/src/series/graph.rs
+++ b/charming/src/series/graph.rs
@@ -1,91 +1,29 @@
+use crate::element::{CoordinateSystem, Label, LabelLayout, LineStyle, ScaleLimit, Tooltip};
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use crate::element::{CoordinateSystem, Label, LabelLayout, LineStyle, ScaleLimit, Tooltip};
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphLayoutCircular {
-    #[serde(skip_serializing_if = "Option::is_none")]
     rotate_label: Option<bool>,
 }
 
-impl Default for GraphLayoutCircular {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl GraphLayoutCircular {
-    pub fn new() -> Self {
-        Self { rotate_label: None }
-    }
-
-    pub fn rotate_label(mut self, rotate_label: bool) -> Self {
-        self.rotate_label = Some(rotate_label);
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphLayoutForce {
-    #[serde(skip_serializing_if = "Option::is_none")]
     init_layout: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     gravity: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     edge_length: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     layout_animation: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     friction: Option<f64>,
-}
-
-impl Default for GraphLayoutForce {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl GraphLayoutForce {
-    pub fn new() -> Self {
-        Self {
-            init_layout: None,
-            gravity: None,
-            edge_length: None,
-            layout_animation: None,
-            friction: None,
-        }
-    }
-
-    pub fn init_layout<S: Into<String>>(mut self, init_layout: S) -> Self {
-        self.init_layout = Some(init_layout.into());
-        self
-    }
-
-    pub fn gravity(mut self, gravity: f64) -> Self {
-        self.gravity = Some(gravity);
-        self
-    }
-
-    pub fn edge_length(mut self, edge_length: f64) -> Self {
-        self.edge_length = Some(edge_length);
-        self
-    }
-
-    pub fn layout_animation(mut self, layout_animation: bool) -> Self {
-        self.layout_animation = Some(layout_animation);
-        self
-    }
-
-    pub fn friction(mut self, friction: f64) -> Self {
-        self.friction = Some(friction);
-        self
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
@@ -107,67 +45,18 @@ impl From<&str> for GraphLayout {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphNodeLabel {
-    #[serde(skip_serializing_if = "Option::is_none")]
     show: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     position: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     formatter: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<String>,
-
-    //TODO: I think this should be f64, would be a breaking change
-    #[serde(skip_serializing_if = "Option::is_none")]
-    font_size: Option<u64>,
-}
-
-impl Default for GraphNodeLabel {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl GraphNodeLabel {
-    pub fn new() -> Self {
-        Self {
-            show: None,
-            position: None,
-            formatter: None,
-            color: None,
-            font_size: None,
-        }
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn position<S: Into<String>>(mut self, position: S) -> Self {
-        self.position = Some(position.into());
-        self
-    }
-
-    pub fn formatter<S: Into<String>>(mut self, formatter: S) -> Self {
-        self.formatter = Some(formatter.into());
-        self
-    }
-
-    pub fn color<S: Into<String>>(mut self, color: S) -> Self {
-        self.color = Some(color.into());
-        self
-    }
-
-    pub fn font_size(mut self, font_size: u64) -> Self {
-        self.font_size = Some(font_size);
-        self
-    }
+    font_size: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
@@ -208,202 +97,45 @@ pub struct GraphData {
     pub categories: Vec<GraphCategory>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Graph {
     #[serde(rename = "type")]
+    #[charming_type = "graph"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     legend_hover_link: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    x_axis_index: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    y_axis_index: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    polar_axis_index: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    geo_index: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    calendar_index: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    x_axis_index: Option<f64>,
+    y_axis_index: Option<f64>,
+    polar_axis_index: Option<f64>,
+    geo_index: Option<f64>,
+    calendar_index: Option<f64>,
     layout: Option<GraphLayout>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     circular: Option<GraphLayoutCircular>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     force: Option<GraphLayoutForce>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     roam: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label_layout: Option<LabelLayout>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     scale_limit: Option<ScaleLimit>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_skip_setter]
     categories: Vec<GraphCategory>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_skip_setter]
     links: Vec<GraphLink>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_skip_setter]
     data: Vec<GraphNode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     edge_symbol: Option<(String, String)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 }
 
-impl Default for Graph {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Graph {
-    pub fn new() -> Self {
-        Self {
-            type_: "graph".into(),
-            id: None,
-            name: None,
-            legend_hover_link: None,
-            coordinate_system: None,
-            x_axis_index: None,
-            y_axis_index: None,
-            polar_axis_index: None,
-            geo_index: None,
-            calendar_index: None,
-            layout: None,
-            circular: None,
-            force: None,
-            roam: None,
-            label: None,
-            label_layout: None,
-            scale_limit: None,
-            line_style: None,
-            categories: vec![],
-            links: vec![],
-            data: vec![],
-            edge_symbol: None,
-            tooltip: None,
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn legend_hover_link(mut self, legend_hover_link: bool) -> Self {
-        self.legend_hover_link = Some(legend_hover_link);
-        self
-    }
-
-    pub fn coordinate_system(mut self, coordinate_system: CoordinateSystem) -> Self {
-        self.coordinate_system = Some(coordinate_system);
-        self
-    }
-
-    pub fn x_axis_index(mut self, x_axis_index: u64) -> Self {
-        self.x_axis_index = Some(x_axis_index);
-        self
-    }
-
-    pub fn y_axis_index(mut self, y_axis_index: u64) -> Self {
-        self.y_axis_index = Some(y_axis_index);
-        self
-    }
-
-    pub fn polar_axis_index(mut self, polar_axis_index: u64) -> Self {
-        self.polar_axis_index = Some(polar_axis_index);
-        self
-    }
-
-    pub fn geo_index(mut self, geo_index: u64) -> Self {
-        self.geo_index = Some(geo_index);
-        self
-    }
-
-    pub fn calendar_index(mut self, calendar_index: u64) -> Self {
-        self.calendar_index = Some(calendar_index);
-        self
-    }
-
-    pub fn layout(mut self, layout: GraphLayout) -> Self {
-        self.layout = Some(layout);
-        self
-    }
-
-    pub fn circular(mut self, circular: GraphLayoutCircular) -> Self {
-        self.circular = Some(circular);
-        self
-    }
-
-    pub fn force(mut self, force: GraphLayoutForce) -> Self {
-        self.force = Some(force);
-        self
-    }
-
-    pub fn roam(mut self, roam: bool) -> Self {
-        self.roam = Some(roam);
-        self
-    }
-
-    pub fn label(mut self, label: Label) -> Self {
-        self.label = Some(label);
-        self
-    }
-
-    pub fn label_layout(mut self, label_layout: LabelLayout) -> Self {
-        self.label_layout = Some(label_layout);
-        self
-    }
-
-    pub fn scale_limit(mut self, scale_limit: ScaleLimit) -> Self {
-        self.scale_limit = Some(scale_limit);
-        self
-    }
-
-    pub fn line_style(mut self, line_style: LineStyle) -> Self {
-        self.line_style = Some(line_style);
-        self
-    }
-
     pub fn data(mut self, data: GraphData) -> Self {
         self.data = data.nodes;
         self.links = data.links;
@@ -413,11 +145,6 @@ impl Graph {
 
     pub fn edge_symbol(mut self, edge_symbol: Option<(String, String)>) -> Self {
         self.edge_symbol = edge_symbol;
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
         self
     }
 }

--- a/charming/src/series/heatmap.rs
+++ b/charming/src/series/heatmap.rs
@@ -1,190 +1,37 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::DataFrame,
     element::{CoordinateSystem, Emphasis, ItemStyle, Label, Tooltip},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Heatmap {
     #[serde(rename = "type")]
+    #[charming_type = "heatmap"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     geo_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     calendar_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     point_size: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     blur_size: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     min_opacity: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_opacity: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     progressive: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     progressive_threshold: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<DataFrame>,
-}
-
-impl Default for Heatmap {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Heatmap {
-    pub fn new() -> Self {
-        Self {
-            type_: "heatmap".to_string(),
-            id: None,
-            name: None,
-            coordinate_system: None,
-            x_axis_index: None,
-            y_axis_index: None,
-            geo_index: None,
-            calendar_index: None,
-            point_size: None,
-            blur_size: None,
-            min_opacity: None,
-            max_opacity: None,
-            progressive: None,
-            progressive_threshold: None,
-            label: None,
-            item_style: None,
-            emphasis: None,
-            tooltip: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn coordinate_system(mut self, coordinate_system: CoordinateSystem) -> Self {
-        self.coordinate_system = Some(coordinate_system);
-        self
-    }
-
-    pub fn x_axis_index<F: Into<f64>>(mut self, x_axis_index: F) -> Self {
-        self.x_axis_index = Some(x_axis_index.into());
-        self
-    }
-
-    pub fn y_axis_index<F: Into<f64>>(mut self, y_axis_index: F) -> Self {
-        self.y_axis_index = Some(y_axis_index.into());
-        self
-    }
-
-    pub fn geo_index<F: Into<f64>>(mut self, geo_index: F) -> Self {
-        self.geo_index = Some(geo_index.into());
-        self
-    }
-
-    pub fn calendar_index<F: Into<f64>>(mut self, calendar_index: F) -> Self {
-        self.calendar_index = Some(calendar_index.into());
-        self
-    }
-
-    pub fn point_size<F: Into<f64>>(mut self, point_size: F) -> Self {
-        self.point_size = Some(point_size.into());
-        self
-    }
-
-    pub fn blur_size<F: Into<f64>>(mut self, blur_size: F) -> Self {
-        self.blur_size = Some(blur_size.into());
-        self
-    }
-
-    pub fn min_opacity<F: Into<f64>>(mut self, min_opacity: F) -> Self {
-        self.min_opacity = Some(min_opacity.into());
-        self
-    }
-
-    pub fn max_opacity<F: Into<f64>>(mut self, max_opacity: F) -> Self {
-        self.max_opacity = Some(max_opacity.into());
-        self
-    }
-
-    pub fn progressive<F: Into<f64>>(mut self, progressive: F) -> Self {
-        self.progressive = Some(progressive.into());
-        self
-    }
-
-    pub fn progressive_threshold<F: Into<f64>>(mut self, progressive_threshold: F) -> Self {
-        self.progressive_threshold = Some(progressive_threshold.into());
-        self
-    }
-
-    pub fn label(mut self, label: Label) -> Self {
-        self.label = Some(label);
-        self
-    }
-
-    pub fn item_style(mut self, item_style: ItemStyle) -> Self {
-        self.item_style = Some(item_style);
-        self
-    }
-
-    pub fn emphasis(mut self, emphasis: Emphasis) -> Self {
-        self.emphasis = Some(emphasis);
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
-    pub fn data<S: Into<DataFrame>>(mut self, data: Vec<S>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/line.rs
+++ b/charming/src/series/line.rs
@@ -46,13 +46,5 @@ pub struct Line {
     silent: Option<bool>,
     z: Option<i32>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
     data: DataFrame,
-}
-
-impl Line {
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/line.rs
+++ b/charming/src/series/line.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{
@@ -8,267 +6,51 @@ use crate::{
         Tooltip,
     },
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Line {
     #[serde(rename = "type")]
+    #[charming_type = "line"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol: Option<Symbol>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_size: Option<SymbolSize>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     show_symbol: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     stack: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     sampling: Option<Sampling>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     area_style: Option<AreaStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     smooth: Option<Smoothness>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     step: Option<Step>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     connect_nulls: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     mark_point: Option<MarkPoint>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     mark_line: Option<MarkLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     mark_area: Option<MarkArea>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     dataset_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     encode: Option<DimensionEncode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     silent: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<i32>,
-
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
 }
 
-impl Default for Line {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Line {
-    pub fn new() -> Self {
-        Self {
-            type_: "line".to_string(),
-            id: None,
-            name: None,
-            coordinate_system: None,
-            symbol: None,
-            symbol_size: None,
-            show_symbol: None,
-            stack: None,
-            sampling: None,
-            label: None,
-            line_style: None,
-            area_style: None,
-            item_style: None,
-            emphasis: None,
-            smooth: None,
-            step: None,
-            connect_nulls: None,
-            mark_point: None,
-            mark_line: None,
-            mark_area: None,
-            dataset_id: None,
-            encode: None,
-            x_axis_index: None,
-            y_axis_index: None,
-            tooltip: None,
-            silent: None,
-            z: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    /// Series name used for displaying in `tooltip` and filtering with `legend`.
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn coordinate_system<C: Into<CoordinateSystem>>(mut self, coordinate_system: C) -> Self {
-        self.coordinate_system = Some(coordinate_system.into());
-        self
-    }
-
-    pub fn symbol<S: Into<Symbol>>(mut self, symbol: S) -> Self {
-        self.symbol = Some(symbol.into());
-        self
-    }
-
-    pub fn symbol_size<F: Into<SymbolSize>>(mut self, symbol_size: F) -> Self {
-        self.symbol_size = Some(symbol_size.into());
-        self
-    }
-
-    pub fn show_symbol(mut self, show_symbol: bool) -> Self {
-        self.show_symbol = Some(show_symbol);
-        self
-    }
-
-    pub fn stack<S: Into<String>>(mut self, stack: S) -> Self {
-        self.stack = Some(stack.into());
-        self
-    }
-
-    pub fn sampling(mut self, sampling: Sampling) -> Self {
-        self.sampling = Some(sampling);
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn line_style<L: Into<LineStyle>>(mut self, line_style: L) -> Self {
-        self.line_style = Some(line_style.into());
-        self
-    }
-
-    pub fn area_style<A: Into<AreaStyle>>(mut self, area_style: A) -> Self {
-        self.area_style = Some(area_style.into());
-        self
-    }
-
-    pub fn item_style<I: Into<ItemStyle>>(mut self, item_style: I) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
-        self
-    }
-
-    /// Smoothness.
-    pub fn smooth<S: Into<Smoothness>>(mut self, smooth: S) -> Self {
-        self.smooth = Some(smooth.into());
-        self
-    }
-
-    pub fn step<S: Into<Step>>(mut self, step: S) -> Self {
-        self.step = Some(step.into());
-        self
-    }
-
-    pub fn connect_nulls(mut self, connect_nulls: bool) -> Self {
-        self.connect_nulls = Some(connect_nulls);
-        self
-    }
-
-    pub fn mark_point<M: Into<MarkPoint>>(mut self, mark_point: M) -> Self {
-        self.mark_point = Some(mark_point.into());
-        self
-    }
-
-    pub fn mark_line<M: Into<MarkLine>>(mut self, mark_line: M) -> Self {
-        self.mark_line = Some(mark_line.into());
-        self
-    }
-
-    pub fn mark_area<M: Into<MarkArea>>(mut self, mark_area: M) -> Self {
-        self.mark_area = Some(mark_area.into());
-        self
-    }
-
-    pub fn dataset_id<S: Into<String>>(mut self, dataset_id: S) -> Self {
-        self.dataset_id = Some(dataset_id.into());
-        self
-    }
-
-    pub fn encode<E: Into<DimensionEncode>>(mut self, encode: E) -> Self {
-        self.encode = Some(encode.into());
-        self
-    }
-
-    pub fn x_axis_index<F: Into<f64>>(mut self, x_axis_index: F) -> Self {
-        self.x_axis_index = Some(x_axis_index.into());
-        self
-    }
-
-    pub fn y_axis_index<F: Into<f64>>(mut self, y_axis_index: F) -> Self {
-        self.y_axis_index = Some(y_axis_index.into());
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
-    pub fn silent(mut self, silent: bool) -> Self {
-        self.silent = Some(silent);
-        self
-    }
-
-    pub fn z<I: Into<i32>>(mut self, z: I) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
     pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
         self.data = data.into_iter().map(|d| d.into()).collect();
         self

--- a/charming/src/series/lines.rs
+++ b/charming/src/series/lines.rs
@@ -1,65 +1,36 @@
 #![allow(dead_code)]
 
-use serde::Serialize;
-
 use crate::element::{
     ColorBy, CoordinateSystem, Emphasis, Label, LabelLayout, LineStyle, Symbol, Tooltip,
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Lines {
     #[serde(rename = "type")]
+    #[charming_type = "lines"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     geo_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     polyline: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     large: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     large_threshold: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol: Option<Symbol>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_size: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label_layout: Option<LabelLayout>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
 }

--- a/charming/src/series/parallel.rs
+++ b/charming/src/series/parallel.rs
@@ -1,9 +1,9 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{smoothness::Smoothness, ColorBy, CoordinateSystem, Emphasis, LineStyle},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -12,160 +12,35 @@ pub enum ProgressiveChunkMode {
     Mod,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Parallel {
     #[serde(rename = "type")]
+    #[charming_type = "parallel"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     parallel_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     inactive_opacity: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     active_opacity: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     realtime: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     smooth: Option<Smoothness>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     progressive: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     progressive_threshold: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     progressive_chunk_mode: Option<ProgressiveChunkMode>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
 }
-
-impl Default for Parallel {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Parallel {
-    pub fn new() -> Self {
-        Self {
-            type_: "parallel".to_string(),
-            id: None,
-            coordinate_system: None,
-            parallel_index: None,
-            name: None,
-            color_by: None,
-            line_style: None,
-            emphasis: None,
-            inactive_opacity: None,
-            active_opacity: None,
-            realtime: None,
-            smooth: None,
-            progressive: None,
-            progressive_threshold: None,
-            progressive_chunk_mode: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn coordinate_system<C: Into<CoordinateSystem>>(mut self, coordinate_system: C) -> Self {
-        self.coordinate_system = Some(coordinate_system.into());
-        self
-    }
-
-    pub fn parallel_index<F: Into<f64>>(mut self, parallel_index: F) -> Self {
-        self.parallel_index = Some(parallel_index.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn color_by<C: Into<ColorBy>>(mut self, color_by: C) -> Self {
-        self.color_by = Some(color_by.into());
-        self
-    }
-
-    pub fn line_style<S: Into<LineStyle>>(mut self, line_style: S) -> Self {
-        self.line_style = Some(line_style.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
-        self
-    }
-
-    pub fn inactive_opacity<F: Into<f64>>(mut self, inactive_opacity: F) -> Self {
-        self.inactive_opacity = Some(inactive_opacity.into());
-        self
-    }
-
-    pub fn active_opacity<F: Into<f64>>(mut self, active_opacity: F) -> Self {
-        self.active_opacity = Some(active_opacity.into());
-        self
-    }
-
-    pub fn realtime(mut self, realtime: bool) -> Self {
-        self.realtime = Some(realtime);
-        self
-    }
-
-    pub fn smooth<S: Into<Smoothness>>(mut self, smooth: S) -> Self {
-        self.smooth = Some(smooth.into());
-        self
-    }
-
-    pub fn progressive<F: Into<f64>>(mut self, progressive: F) -> Self {
-        self.progressive = Some(progressive.into());
-        self
-    }
-
-    pub fn progressive_threshold<F: Into<f64>>(mut self, progressive_threshold: F) -> Self {
-        self.progressive_threshold = Some(progressive_threshold.into());
-        self
-    }
-
-    pub fn progressive_chunk_mode<P: Into<ProgressiveChunkMode>>(
-        mut self,
-        progressive_chunk_mode: P,
-    ) -> Self {
-        self.progressive_chunk_mode = Some(progressive_chunk_mode.into());
-        self
-    }
-
     pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
         self.data = data.into_iter().map(|d| d.into()).collect();
         self

--- a/charming/src/series/parallel.rs
+++ b/charming/src/series/parallel.rs
@@ -37,12 +37,5 @@ pub struct Parallel {
     progressive_threshold: Option<f64>,
     progressive_chunk_mode: Option<ProgressiveChunkMode>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
     data: DataFrame,
-}
-impl Parallel {
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/pictorial_bar.rs
+++ b/charming/src/series/pictorial_bar.rs
@@ -1,174 +1,37 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::DataFrame,
     element::{
         ColorBy, CoordinateSystem, Cursor, Emphasis, ItemStyle, Label, LabelLayout, LabelLine,
     },
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PictorialBar {
     #[serde(rename = "type")]
+    #[charming_type = "pictorialBar"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     legend_hover_link: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     cursor: Option<Cursor>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label_line: Option<LabelLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label_layout: Option<LabelLayout>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_clip: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_bounding_data: Option<f64>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<DataFrame>,
-}
-
-impl Default for PictorialBar {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PictorialBar {
-    pub fn new() -> Self {
-        PictorialBar {
-            type_: "pictorialBar".to_string(),
-            id: None,
-            name: None,
-            color_by: None,
-            legend_hover_link: None,
-            coordinate_system: None,
-            x_axis_index: None,
-            y_axis_index: None,
-            cursor: None,
-            label: None,
-            label_line: None,
-            label_layout: None,
-            item_style: None,
-            emphasis: None,
-            symbol_clip: None,
-            symbol_bounding_data: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn color_by<C: Into<ColorBy>>(mut self, color_by: C) -> Self {
-        self.color_by = Some(color_by.into());
-        self
-    }
-
-    pub fn legend_hover_link(mut self, legend_hover_link: bool) -> Self {
-        self.legend_hover_link = Some(legend_hover_link);
-        self
-    }
-
-    pub fn coordinate_system<C: Into<CoordinateSystem>>(mut self, coordinate_system: C) -> Self {
-        self.coordinate_system = Some(coordinate_system.into());
-        self
-    }
-
-    pub fn x_axis_index<F: Into<f64>>(mut self, x_axis_index: F) -> Self {
-        self.x_axis_index = Some(x_axis_index.into());
-        self
-    }
-
-    pub fn y_axis_index<F: Into<f64>>(mut self, y_axis_index: F) -> Self {
-        self.y_axis_index = Some(y_axis_index.into());
-        self
-    }
-
-    pub fn cursor<C: Into<Cursor>>(mut self, cursor: C) -> Self {
-        self.cursor = Some(cursor.into());
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn label_line<L: Into<LabelLine>>(mut self, label_line: L) -> Self {
-        self.label_line = Some(label_line.into());
-        self
-    }
-
-    pub fn label_layout<L: Into<LabelLayout>>(mut self, label_layout: L) -> Self {
-        self.label_layout = Some(label_layout.into());
-        self
-    }
-
-    pub fn item_style<I: Into<ItemStyle>>(mut self, item_style: I) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
-        self
-    }
-
-    pub fn symbol_clip(mut self, symbol_clip: bool) -> Self {
-        self.symbol_clip = Some(symbol_clip);
-        self
-    }
-
-    pub fn symbol_bounding_data<F: Into<f64>>(mut self, symbol_bounding_data: F) -> Self {
-        self.symbol_bounding_data = Some(symbol_bounding_data.into());
-        self
-    }
-
-    pub fn data<D: Into<DataFrame>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/pie.rs
+++ b/charming/src/series/pie.rs
@@ -1,9 +1,9 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::{CompositeValue, DataFrame, DataPoint},
     element::{ColorBy, CoordinateSystem, Emphasis, ItemStyle, Label, LabelLine, Tooltip},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -12,211 +12,42 @@ pub enum PieRoseType {
     Area,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Pie {
     #[serde(rename = "type")]
+    #[charming_type = "pie"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     legend_hover_link: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordiate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     geo_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     calendar_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     selected_mode: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     selected_offset: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     clockwise: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     avoid_label_overlap: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     start_angle: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     rose_type: Option<PieRoseType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label_line: Option<LabelLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     center: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     radius: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
 }
 
-impl Default for Pie {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Pie {
-    pub fn new() -> Self {
-        Pie {
-            type_: "pie".to_string(),
-            id: None,
-            name: None,
-            color_by: None,
-            legend_hover_link: None,
-            coordiate_system: None,
-            geo_index: None,
-            calendar_index: None,
-            selected_mode: None,
-            selected_offset: None,
-            clockwise: None,
-            avoid_label_overlap: None,
-            start_angle: None,
-            rose_type: None,
-            label: None,
-            label_line: None,
-            item_style: None,
-            emphasis: None,
-            center: None,
-            radius: None,
-            tooltip: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn color_by<C: Into<ColorBy>>(mut self, color_by: C) -> Self {
-        self.color_by = Some(color_by.into());
-        self
-    }
-
-    pub fn legend_hover_link(mut self, legend_hover_link: bool) -> Self {
-        self.legend_hover_link = Some(legend_hover_link);
-        self
-    }
-
-    pub fn coordiate_system<C: Into<CoordinateSystem>>(mut self, coordiate_system: C) -> Self {
-        self.coordiate_system = Some(coordiate_system.into());
-        self
-    }
-
-    pub fn geo_index<F: Into<f64>>(mut self, geo_index: F) -> Self {
-        self.geo_index = Some(geo_index.into());
-        self
-    }
-
-    pub fn calendar_index<F: Into<f64>>(mut self, calendar_index: F) -> Self {
-        self.calendar_index = Some(calendar_index.into());
-        self
-    }
-
-    pub fn selected_mode(mut self, selected_mode: bool) -> Self {
-        self.selected_mode = Some(selected_mode);
-        self
-    }
-
-    pub fn selected_offset<F: Into<f64>>(mut self, selected_offset: F) -> Self {
-        self.selected_offset = Some(selected_offset.into());
-        self
-    }
-
-    pub fn clockwise(mut self, clockwise: bool) -> Self {
-        self.clockwise = Some(clockwise);
-        self
-    }
-
-    pub fn avoid_label_overlap(mut self, avoid_label_overlap: bool) -> Self {
-        self.avoid_label_overlap = Some(avoid_label_overlap);
-        self
-    }
-
-    pub fn start_angle<F: Into<f64>>(mut self, start_angle: F) -> Self {
-        self.start_angle = Some(start_angle.into());
-        self
-    }
-
-    pub fn rose_type<P: Into<PieRoseType>>(mut self, rose_type: P) -> Self {
-        self.rose_type = Some(rose_type.into());
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn label_line<L: Into<LabelLine>>(mut self, label_line: L) -> Self {
-        self.label_line = Some(label_line.into());
-        self
-    }
-
-    pub fn item_style<I: Into<ItemStyle>>(mut self, item_style: I) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
-        self
-    }
-
-    pub fn center<C: Into<CompositeValue>>(mut self, center: C) -> Self {
-        self.center = Some(center.into());
-        self
-    }
-
-    pub fn radius<C: Into<CompositeValue>>(mut self, radius: C) -> Self {
-        self.radius = Some(radius.into());
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
     pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
         self.data = data.into_iter().map(|d| d.into()).collect();
         self

--- a/charming/src/series/pie.rs
+++ b/charming/src/series/pie.rs
@@ -43,13 +43,5 @@ pub struct Pie {
     radius: Option<CompositeValue>,
     tooltip: Option<Tooltip>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
     data: DataFrame,
-}
-
-impl Pie {
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/radar.rs
+++ b/charming/src/series/radar.rs
@@ -17,9 +17,6 @@ pub struct Radar {
     type_: String,
     area_style: Option<AreaStyle>,
     color_by: Option<ColorBy>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
-    data: DataFrame,
     id: Option<String>,
     name: Option<String>,
     radar_index: Option<f64>,
@@ -30,11 +27,6 @@ pub struct Radar {
     tooltip: Option<Tooltip>,
     line_style: Option<LineStyle>,
     emphasis: Option<Emphasis>,
-}
-
-impl Radar {
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    data: DataFrame,
 }

--- a/charming/src/series/radar.rs
+++ b/charming/src/series/radar.rs
@@ -1,145 +1,40 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{AreaStyle, ColorBy, Emphasis, LineStyle, Symbol, Tooltip},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Radar {
     #[serde(rename = "type")]
+    #[charming_type = "radar"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     area_style: Option<AreaStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     radar_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol: Option<Symbol>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_keep_aspect: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_rotate: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_size: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
 }
 
-impl Default for Radar {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Radar {
-    pub fn new() -> Self {
-        Self {
-            type_: "radar".into(),
-            area_style: None,
-            color_by: None,
-            data: vec![],
-            id: None,
-            name: None,
-            radar_index: None,
-            symbol: None,
-            symbol_keep_aspect: None,
-            symbol_rotate: None,
-            symbol_size: None,
-            tooltip: None,
-            line_style: None,
-            emphasis: None,
-        }
-    }
-
-    pub fn area_style<A: Into<AreaStyle>>(mut self, area_style: A) -> Self {
-        self.area_style = Some(area_style.into());
-        self
-    }
-
-    pub fn color_by<C: Into<ColorBy>>(mut self, color_by: C) -> Self {
-        self.color_by = Some(color_by.into());
-        self
-    }
-
     pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
         self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn radar_index<F: Into<f64>>(mut self, radar_index: F) -> Self {
-        self.radar_index = Some(radar_index.into());
-        self
-    }
-
-    pub fn symbol<S: Into<Symbol>>(mut self, symbol: S) -> Self {
-        self.symbol = Some(symbol.into());
-        self
-    }
-
-    pub fn symbol_keep_aspect(mut self, symbol_keep_aspect: bool) -> Self {
-        self.symbol_keep_aspect = Some(symbol_keep_aspect);
-        self
-    }
-
-    pub fn symbol_rotate<F: Into<f64>>(mut self, symbol_rotate: F) -> Self {
-        self.symbol_rotate = Some(symbol_rotate.into());
-        self
-    }
-
-    pub fn symbol_size<F: Into<f64>>(mut self, symbol_size: F) -> Self {
-        self.symbol_size = Some(symbol_size.into());
-        self
-    }
-
-    pub fn tooltip<T: Into<Tooltip>>(mut self, tooltip: T) -> Self {
-        self.tooltip = Some(tooltip.into());
-        self
-    }
-
-    pub fn line_style<L: Into<LineStyle>>(mut self, line_style: L) -> Self {
-        self.line_style = Some(line_style.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
         self
     }
 }

--- a/charming/src/series/sankey.rs
+++ b/charming/src/series/sankey.rs
@@ -1,9 +1,9 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{Emphasis, ItemStyle, Label, LineStyle, Orient, Tooltip},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -13,18 +13,16 @@ pub enum SankeyNodeAlign {
     Justify,
 }
 
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SankeyNode {
     pub name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub depth: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub item_style: Option<ItemStyle>,
 }
 
@@ -92,201 +90,42 @@ where
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Sankey {
     #[serde(rename = "type")]
+    #[charming_type = "sankey"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     z_level: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     layout_iterations: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     orient: Option<Orient>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     node_align: Option<SankeyNodeAlign>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     line_style: Option<LineStyle>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     links: Vec<SankeyLink>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<SankeyNode>,
 }
 
-impl Default for Sankey {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Sankey {
-    pub fn new() -> Self {
-        Sankey {
-            type_: "sankey".to_string(),
-            id: None,
-            name: None,
-            z_level: None,
-            z: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            width: None,
-            height: None,
-            emphasis: None,
-            layout_iterations: None,
-            orient: None,
-            label: None,
-            node_align: None,
-            line_style: None,
-            links: vec![],
-            tooltip: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn z_level<F: Into<f64>>(mut self, z_level: F) -> Self {
-        self.z_level = Some(z_level.into());
-        self
-    }
-
-    pub fn z<F: Into<f64>>(mut self, z: F) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
-    pub fn width<F: Into<f64>>(mut self, width: F) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn height<F: Into<f64>>(mut self, height: F) -> Self {
-        self.height = Some(height.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
-        self
-    }
-
-    pub fn layout_iterations<F: Into<u64>>(mut self, layout_iterations: F) -> Self {
-        self.layout_iterations = Some(layout_iterations.into());
-        self
-    }
-
-    pub fn orient<O: Into<Orient>>(mut self, orient: O) -> Self {
-        self.orient = Some(orient.into());
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn node_align<S: Into<SankeyNodeAlign>>(mut self, node_align: S) -> Self {
-        self.node_align = Some(node_align.into());
-        self
-    }
-
-    pub fn line_style<L: Into<LineStyle>>(mut self, line_style: L) -> Self {
-        self.line_style = Some(line_style.into());
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
-    pub fn data<S: Into<SankeyNode>>(mut self, data: Vec<S>) -> Self {
-        self.data = data.into_iter().map(|s| s.into()).collect();
-        self
-    }
-
     pub fn nodes<S: Into<SankeyNode>>(mut self, nodes: Vec<S>) -> Self {
         self.data = nodes.into_iter().map(|s| s.into()).collect();
-        self
-    }
-
-    pub fn links<S: Into<SankeyLink>>(mut self, links: Vec<S>) -> Self {
-        self.links = links.into_iter().map(|s| s.into()).collect();
         self
     }
 }

--- a/charming/src/series/scatter.rs
+++ b/charming/src/series/scatter.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::{DataFrame, DataPoint},
     element::{
@@ -7,167 +5,40 @@ use crate::{
         Symbol, SymbolSize,
     },
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Scatter {
     #[serde(rename = "type")]
+    #[charming_type = "scatter"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     dataset_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     x_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     y_axis_index: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol: Option<Symbol>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_size: Option<SymbolSize>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     encode: Option<DimensionEncode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     mark_line: Option<MarkLine>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     mark_area: Option<MarkArea>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[charming_skip_setter]
     data: DataFrame,
 }
 
-impl Default for Scatter {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Scatter {
-    pub fn new() -> Self {
-        Self {
-            type_: String::from("scatter"),
-            id: None,
-            name: None,
-            color_by: None,
-            label: None,
-            dataset_index: None,
-            coordinate_system: None,
-            x_axis_index: None,
-            y_axis_index: None,
-            symbol: None,
-            symbol_size: None,
-            encode: None,
-            mark_line: None,
-            mark_area: None,
-            item_style: None,
-            emphasis: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn color_by(mut self, color_by: ColorBy) -> Self {
-        self.color_by = Some(color_by);
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn dataset_index<F: Into<f64>>(mut self, dataset_index: F) -> Self {
-        self.dataset_index = Some(dataset_index.into());
-        self
-    }
-
-    pub fn coordinate_system<C: Into<CoordinateSystem>>(mut self, coordinate_system: C) -> Self {
-        self.coordinate_system = Some(coordinate_system.into());
-        self
-    }
-
-    pub fn x_axis_index<F: Into<f64>>(mut self, x_axis_index: F) -> Self {
-        self.x_axis_index = Some(x_axis_index.into());
-        self
-    }
-
-    pub fn y_axis_index<F: Into<f64>>(mut self, y_axis_index: F) -> Self {
-        self.y_axis_index = Some(y_axis_index.into());
-        self
-    }
-
-    pub fn symbol(mut self, symbol: Symbol) -> Self {
-        self.symbol = Some(symbol);
-        self
-    }
-
-    pub fn symbol_size<S: Into<SymbolSize>>(mut self, symbol_size: S) -> Self {
-        self.symbol_size = Some(symbol_size.into());
-        self
-    }
-
-    pub fn encode<D: Into<DimensionEncode>>(mut self, encode: D) -> Self {
-        self.encode = Some(encode.into());
-        self
-    }
-
-    pub fn mark_line<M: Into<MarkLine>>(mut self, mark_line: M) -> Self {
-        self.mark_line = Some(mark_line.into());
-        self
-    }
-
-    pub fn mark_area<M: Into<MarkArea>>(mut self, mark_area: M) -> Self {
-        self.mark_area = Some(mark_area.into());
-        self
-    }
-
-    pub fn item_style<I: Into<ItemStyle>>(mut self, item_style: I) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
-        self
-    }
-
     pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
         self.data = data.into_iter().map(|d| d.into()).collect();
         self

--- a/charming/src/series/scatter.rs
+++ b/charming/src/series/scatter.rs
@@ -34,13 +34,5 @@ pub struct Scatter {
     item_style: Option<ItemStyle>,
     emphasis: Option<Emphasis>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[charming_skip_setter]
     data: DataFrame,
-}
-
-impl Scatter {
-    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/sunburst.rs
+++ b/charming/src/series/sunburst.rs
@@ -1,74 +1,31 @@
+use crate::element::{Emphasis, ItemStyle, Label, Sort, Tooltip};
+use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
 
-use crate::element::{Emphasis, ItemStyle, Label, Sort, Tooltip};
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SunburstLevel {
-    #[serde(skip_serializing_if = "Option::is_none")]
     r0: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     r: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
 }
 
-impl Default for SunburstLevel {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SunburstLevel {
-    pub fn new() -> Self {
-        Self {
-            r0: None,
-            r: None,
-            item_style: None,
-            label: None,
-        }
-    }
-
-    pub fn r0<S: Into<String>>(mut self, r0: S) -> Self {
-        self.r0 = Some(r0.into());
-        self
-    }
-
-    pub fn r<S: Into<String>>(mut self, r: S) -> Self {
-        self.r = Some(r.into());
-        self
-    }
-
-    pub fn item_style(mut self, item_style: ItemStyle) -> Self {
-        self.item_style = Some(item_style);
-        self
-    }
-
-    pub fn label(mut self, label: Label) -> Self {
-        self.label = Some(label);
-        self
-    }
-}
-
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SunburstNode {
     name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(skip_deserializing)]
     item_style: Option<ItemStyle>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     children: Vec<SunburstNode>,
 }
 
@@ -118,92 +75,34 @@ impl From<(&str, f64, &str)> for SunburstNode {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Sunburst {
     #[serde(rename = "type")]
+    #[charming_type = "sunburst"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     z_level: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     center: Option<(String, String)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[charming_skip_setter]
     radius: Option<(String, String)>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     sort: Option<Sort>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     levels: Vec<SunburstLevel>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<SunburstNode>,
 }
 
-impl Default for Sunburst {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Sunburst {
-    pub fn new() -> Self {
-        Self {
-            type_: "sunburst".to_string(),
-            id: None,
-            name: None,
-            z_level: None,
-            z: None,
-            center: None,
-            radius: None,
-            emphasis: None,
-            sort: None,
-            levels: vec![],
-            tooltip: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn z_level(mut self, z_level: u64) -> Self {
-        self.z_level = Some(z_level);
-        self
-    }
-
-    pub fn z(mut self, z: u64) -> Self {
-        self.z = Some(z);
-        self
-    }
-
     pub fn center<S: Into<String>>(mut self, center: (S, S)) -> Self {
         self.center = Some((center.0.into(), center.1.into()));
         self
@@ -211,31 +110,6 @@ impl Sunburst {
 
     pub fn radius<S: Into<String>>(mut self, radius: (S, S)) -> Self {
         self.radius = Some((radius.0.into(), radius.1.into()));
-        self
-    }
-
-    pub fn emphasis(mut self, emphasis: Emphasis) -> Self {
-        self.emphasis = Some(emphasis);
-        self
-    }
-
-    pub fn sort(mut self, sort: Sort) -> Self {
-        self.sort = Some(sort);
-        self
-    }
-
-    pub fn levels(mut self, levels: Vec<SunburstLevel>) -> Self {
-        self.levels = levels;
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
-    pub fn data(mut self, data: Vec<SunburstNode>) -> Self {
-        self.data = data;
         self
     }
 }

--- a/charming/src/series/theme_river.rs
+++ b/charming/src/series/theme_river.rs
@@ -1,12 +1,12 @@
+use crate::{
+    datatype::CompositeValue,
+    element::{BoundaryGap, ColorBy, CoordinateSystem, Label, Tooltip},
+};
+use charming_macros::CharmingSetters;
 use serde::{
     de::{SeqAccess, Visitor},
     ser::SerializeSeq,
     Deserialize, Deserializer, Serialize,
-};
-
-use crate::{
-    datatype::CompositeValue,
-    element::{BoundaryGap, ColorBy, CoordinateSystem, Label, Tooltip},
 };
 
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
@@ -88,150 +88,29 @@ where
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ThemeRiver {
     #[serde(rename = "type")]
+    #[charming_type = "themeRiver"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     color_by: Option<ColorBy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     coordinate_system: Option<CoordinateSystem>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     boundary_gap: Option<BoundaryGap>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<ThemeRiverData>,
-}
-
-impl Default for ThemeRiver {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ThemeRiver {
-    pub fn new() -> Self {
-        Self {
-            type_: "themeRiver".to_string(),
-            id: None,
-            name: None,
-            color_by: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            width: None,
-            height: None,
-            coordinate_system: None,
-            boundary_gap: None,
-            label: None,
-            tooltip: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn color_by(mut self, color_by: ColorBy) -> Self {
-        self.color_by = Some(color_by);
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
-    pub fn width<C: Into<CompositeValue>>(mut self, width: C) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn height<C: Into<CompositeValue>>(mut self, height: C) -> Self {
-        self.height = Some(height.into());
-        self
-    }
-
-    pub fn coordinate_system<C: Into<CoordinateSystem>>(mut self, coordinate_system: C) -> Self {
-        self.coordinate_system = Some(coordinate_system.into());
-        self
-    }
-
-    pub fn boundary_gap<B: Into<BoundaryGap>>(mut self, boundary_gap: B) -> Self {
-        self.boundary_gap = Some(boundary_gap.into());
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
-    pub fn data<T: Into<ThemeRiverData>>(mut self, data: Vec<T>) -> Self {
-        self.data = data.into_iter().map(|d| d.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/tree.rs
+++ b/charming/src/series/tree.rs
@@ -1,9 +1,9 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{Blur, Emphasis, ItemStyle, Label, Select, Symbol, Tooltip},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -31,383 +31,78 @@ pub enum TreeEdgeShape {
     Polyline,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TreeLeaves {
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
 }
 
-impl Default for TreeLeaves {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl TreeLeaves {
-    pub fn new() -> Self {
-        Self { label: None }
-    }
-
-    pub fn label(mut self, label: Label) -> Self {
-        self.label = Some(label);
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TreeNode {
-    pub name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     pub value: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub collapsed: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<TreeNode>>,
 }
 
 /// The tree diagram is mainly used to display the tree data structure.
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Tree {
     #[serde(rename = "type")]
+    #[charming_type = "tree"]
     type_: String,
-
     /// Component ID.
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
     /// Component name.
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
     /// zlevel value of all graphical elements in the tree.
-    #[serde(skip_serializing_if = "Option::is_none")]
     z_level: Option<u64>,
-
     /// z value of all graphical elements in the tree.
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     center: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     zoom: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     layout: Option<TreeLayout>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     orient: Option<TreeOrient>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol: Option<Symbol>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_size: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_rotate: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_keep_aspect: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     symbol_offset: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     edge_shape: Option<TreeEdgeShape>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     edge_fork_position: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     roam: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     initial_tree_depth: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     blur: Option<Blur>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     select: Option<Select>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     selected_mode: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     expand_and_collapse: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation_duration: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     animation_duration_update: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     leaves: Option<TreeLeaves>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[charming_set_vec]
     data: Vec<TreeNode>,
-}
-
-impl Default for Tree {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Tree {
-    pub fn new() -> Self {
-        Self {
-            type_: "tree".into(),
-            id: None,
-            name: None,
-            z_level: None,
-            z: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            width: None,
-            height: None,
-            center: None,
-            zoom: None,
-            layout: None,
-            orient: None,
-            symbol: None,
-            symbol_size: None,
-            symbol_rotate: None,
-            symbol_keep_aspect: None,
-            symbol_offset: None,
-            edge_shape: None,
-            edge_fork_position: None,
-            roam: None,
-            initial_tree_depth: None,
-            item_style: None,
-            label: None,
-            emphasis: None,
-            blur: None,
-            select: None,
-            selected_mode: None,
-            expand_and_collapse: None,
-            animation_duration: None,
-            animation_duration_update: None,
-            leaves: None,
-            tooltip: None,
-            data: vec![],
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn z_level(mut self, z_level: u64) -> Self {
-        self.z_level = Some(z_level);
-        self
-    }
-
-    pub fn z(mut self, z: u64) -> Self {
-        self.z = Some(z);
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
-    pub fn width<C: Into<CompositeValue>>(mut self, width: C) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn height<C: Into<CompositeValue>>(mut self, height: C) -> Self {
-        self.height = Some(height.into());
-        self
-    }
-
-    pub fn center<C: Into<CompositeValue>>(mut self, center: C) -> Self {
-        self.center = Some(center.into());
-        self
-    }
-
-    pub fn zoom<F: Into<f64>>(mut self, zoom: F) -> Self {
-        self.zoom = Some(zoom.into());
-        self
-    }
-
-    pub fn layout<T: Into<TreeLayout>>(mut self, layout: T) -> Self {
-        self.layout = Some(layout.into());
-        self
-    }
-
-    pub fn orient<T: Into<TreeOrient>>(mut self, orient: T) -> Self {
-        self.orient = Some(orient.into());
-        self
-    }
-
-    pub fn symbol<S: Into<Symbol>>(mut self, symbol: S) -> Self {
-        self.symbol = Some(symbol.into());
-        self
-    }
-
-    pub fn symbol_size<F: Into<f64>>(mut self, symbol_size: F) -> Self {
-        self.symbol_size = Some(symbol_size.into());
-        self
-    }
-
-    pub fn symbol_rotate<F: Into<f64>>(mut self, symbol_rotate: F) -> Self {
-        self.symbol_rotate = Some(symbol_rotate.into());
-        self
-    }
-
-    pub fn symbol_keep_aspect(mut self, symbol_keep_aspect: bool) -> Self {
-        self.symbol_keep_aspect = Some(symbol_keep_aspect);
-        self
-    }
-
-    pub fn symbol_offset<C: Into<CompositeValue>>(mut self, symbol_offset: C) -> Self {
-        self.symbol_offset = Some(symbol_offset.into());
-        self
-    }
-
-    pub fn edge_shape<T: Into<TreeEdgeShape>>(mut self, edge_shape: T) -> Self {
-        self.edge_shape = Some(edge_shape.into());
-        self
-    }
-
-    pub fn edge_fork_position<S: Into<String>>(mut self, edge_fork_position: S) -> Self {
-        self.edge_fork_position = Some(edge_fork_position.into());
-        self
-    }
-
-    pub fn roam(mut self, roam: bool) -> Self {
-        self.roam = Some(roam);
-        self
-    }
-
-    pub fn initial_tree_depth<F: Into<f64>>(mut self, initial_tree_depth: F) -> Self {
-        self.initial_tree_depth = Some(initial_tree_depth.into());
-        self
-    }
-
-    pub fn item_style<I: Into<ItemStyle>>(mut self, item_style: I) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
-        self
-    }
-
-    pub fn blur<B: Into<Blur>>(mut self, blur: B) -> Self {
-        self.blur = Some(blur.into());
-        self
-    }
-
-    pub fn select<S: Into<Select>>(mut self, select: S) -> Self {
-        self.select = Some(select.into());
-        self
-    }
-
-    pub fn selected_mode(mut self, selected_mode: bool) -> Self {
-        self.selected_mode = Some(selected_mode);
-        self
-    }
-
-    pub fn expand_and_collapse(mut self, expand_and_collapse: bool) -> Self {
-        self.expand_and_collapse = Some(expand_and_collapse);
-        self
-    }
-
-    pub fn animation_duration<F: Into<f64>>(mut self, animation_duration: F) -> Self {
-        self.animation_duration = Some(animation_duration.into());
-        self
-    }
-
-    pub fn animation_duration_update<F: Into<f64>>(mut self, animation_duration_update: F) -> Self {
-        self.animation_duration_update = Some(animation_duration_update.into());
-        self
-    }
-
-    pub fn leaves<T: Into<TreeLeaves>>(mut self, leaves: T) -> Self {
-        self.leaves = Some(leaves.into());
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
-
-    pub fn data<T: Into<TreeNode>>(mut self, data: Vec<T>) -> Self {
-        self.data = data.into_iter().map(|t| t.into()).collect();
-        self
-    }
 }

--- a/charming/src/series/treemap.rs
+++ b/charming/src/series/treemap.rs
@@ -1,153 +1,32 @@
-use serde::{Deserialize, Serialize};
-
 use crate::{
     datatype::CompositeValue,
     element::{Emphasis, ItemStyle, Label, Tooltip},
 };
+use charming_macros::CharmingSetters;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
+#[serde_with::apply(
+  Option => #[serde(skip_serializing_if = "Option::is_none")],
+  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
+)]
+#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Treemap {
     #[serde(rename = "type")]
+    #[charming_type = "treemap"]
     type_: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     zlevel: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     z: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     left: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     top: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     right: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     bottom: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<CompositeValue>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     label: Option<Label>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     item_style: Option<ItemStyle>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     emphasis: Option<Emphasis>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     tooltip: Option<Tooltip>,
-}
-
-impl Default for Treemap {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Treemap {
-    pub fn new() -> Self {
-        Treemap {
-            type_: "treemap".to_string(),
-            id: None,
-            name: None,
-            zlevel: None,
-            z: None,
-            left: None,
-            top: None,
-            right: None,
-            bottom: None,
-            width: None,
-            height: None,
-            label: None,
-            item_style: None,
-            emphasis: None,
-            tooltip: None,
-        }
-    }
-
-    pub fn id<S: Into<String>>(mut self, id: S) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
-    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
-        self.name = Some(name.into());
-        self
-    }
-
-    pub fn zlevel<F: Into<f64>>(mut self, zlevel: F) -> Self {
-        self.zlevel = Some(zlevel.into());
-        self
-    }
-
-    pub fn z<F: Into<f64>>(mut self, z: F) -> Self {
-        self.z = Some(z.into());
-        self
-    }
-
-    pub fn left<C: Into<CompositeValue>>(mut self, left: C) -> Self {
-        self.left = Some(left.into());
-        self
-    }
-
-    pub fn top<C: Into<CompositeValue>>(mut self, top: C) -> Self {
-        self.top = Some(top.into());
-        self
-    }
-
-    pub fn right<C: Into<CompositeValue>>(mut self, right: C) -> Self {
-        self.right = Some(right.into());
-        self
-    }
-
-    pub fn bottom<C: Into<CompositeValue>>(mut self, bottom: C) -> Self {
-        self.bottom = Some(bottom.into());
-        self
-    }
-
-    pub fn width<C: Into<CompositeValue>>(mut self, width: C) -> Self {
-        self.width = Some(width.into());
-        self
-    }
-
-    pub fn height<C: Into<CompositeValue>>(mut self, height: C) -> Self {
-        self.height = Some(height.into());
-        self
-    }
-
-    pub fn label<L: Into<Label>>(mut self, label: L) -> Self {
-        self.label = Some(label.into());
-        self
-    }
-
-    pub fn item_style<I: Into<ItemStyle>>(mut self, item_style: I) -> Self {
-        self.item_style = Some(item_style.into());
-        self
-    }
-
-    pub fn emphasis<E: Into<Emphasis>>(mut self, emphasis: E) -> Self {
-        self.emphasis = Some(emphasis.into());
-        self
-    }
-
-    pub fn tooltip(mut self, tooltip: Tooltip) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
 }

--- a/charming_macros/Cargo.toml
+++ b/charming_macros/Cargo.toml
@@ -10,3 +10,8 @@ proc-macro = true
 proc-macro2 = "1.0.95"
 quote = "1.0.40"
 syn = "2.0.101"
+
+[dev-dependencies]
+charming = { path = "../charming" }
+serde = { version = "1.0", features = ["derive"] }
+serde_with = "3.11.0"

--- a/charming_macros/Cargo.toml
+++ b/charming_macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "charming_macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.95"
+quote = "1.0.40"
+syn = "2.0.101"

--- a/charming_macros/src/lib.rs
+++ b/charming_macros/src/lib.rs
@@ -149,6 +149,15 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                         pub fn #field_ident<#field_ident_shorthand: Into #field_generic_type >(mut self, #field_ident: #field_ident_shorthand) -> Self {self.#field_ident.push(#field_ident.into());
                         self}
                     });
+                } else if type_wrapper == "DataFrame" && generate_setter {
+                    fields_init_values.push(quote! { #field_ident: DataFrame::default() });
+
+                    fields_setter.push(quote! {
+                        pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
+                            self.data = data.into_iter().map(|d| d.into()).collect();
+                            self
+                        }
+                    });
                 };
             }
             _ => todo!(),

--- a/charming_macros/src/lib.rs
+++ b/charming_macros/src/lib.rs
@@ -1,0 +1,170 @@
+use proc_macro2::{Ident, Span};
+use quote::quote;
+use syn::{ItemStruct, parse_macro_input};
+
+#[proc_macro_derive(
+    CharmingSetters,
+    attributes(charming_skip_setter, charming_type, charming_set_vec)
+)]
+pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    let struct_ident = input.ident;
+    let mut fields_init_values = Vec::with_capacity(input.fields.len());
+    let mut fields_setter = Vec::with_capacity(input.fields.len());
+
+    for field in input.fields {
+        let mut generate_setter = true;
+
+        let field_ident = field.ident.unwrap();
+        let field_string_shorthand = field_ident
+            .to_string()
+            .chars()
+            .next()
+            .unwrap()
+            .to_string()
+            .to_uppercase();
+
+        let field_ident_shorthand = Ident::new(&field_string_shorthand, Span::call_site());
+
+        match field.ty {
+            syn::Type::Path(type_path) => {
+                // type_wrapper will be the first type `type_path: Option<T> -> type_wrapper = "Option"`
+                let type_wrapper = &type_path.path.segments.first().unwrap().ident.to_string();
+
+                for attribute in field.attrs {
+                    match attribute.meta {
+                        syn::Meta::Path(path) => {
+                            if let Some(segment) = path.segments.last() {
+                                match segment.ident.to_string().as_str() {
+                                    // `charming_skip_setter` will skip the automatic setter implementation
+                                    "charming_skip_setter" => {
+                                        if type_wrapper == "Option" {
+                                            fields_init_values.push(quote! { #field_ident: None });
+                                        } else if type_wrapper == "Vec" {
+                                            fields_init_values
+                                                .push(quote! { #field_ident: Vec::new() });
+                                        } else {
+                                            fields_init_values
+                                                .push(quote! { #field_ident: Default::default() });
+                                        }
+
+                                        generate_setter = false;
+                                    }
+                                    // `charming_set_vec` will implement a setter method where the vec is set at once
+                                    "charming_set_vec" => {
+                                        let field_string_lowercase_shorthand =
+                                            field_string_shorthand.to_lowercase();
+                                        let field_ident_lowercase_shorthand = Ident::new(
+                                            &field_string_lowercase_shorthand,
+                                            Span::call_site(),
+                                        );
+                                        let field_generic_type = &type_path
+                                            .path
+                                            .segments
+                                            .iter()
+                                            .next()
+                                            .unwrap()
+                                            .arguments;
+
+                                        fields_init_values
+                                            .push(quote! { #field_ident: Vec::new() });
+
+                                        // This implements a method that looks like this for a field `dimension: Vec<Dimension>`
+                                        //```rust
+                                        //pub fn dimensions<D: Into<Dimension>>(mut self, dimensions: Vec<D>) -> Self {
+                                        //    self.dimensions = dimensions.into_iter().map(|d| d.into()).collect();
+                                        //    self
+                                        //}
+                                        // ```
+                                        fields_setter.push(quote! {
+                                            pub fn #field_ident<#field_ident_shorthand: Into #field_generic_type>(mut self, #field_ident: Vec<#field_ident_shorthand>) -> Self {
+                                                self.#field_ident = #field_ident.into_iter().map(|#field_ident_lowercase_shorthand| #field_ident_lowercase_shorthand.into()).collect();
+                                                self
+                                            }
+                                        });
+
+                                        generate_setter = false;
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                        syn::Meta::List(_meta_list) => (),
+                        syn::Meta::NameValue(meta_name_value) => {
+                            if let Some(segment) = meta_name_value.path.segments.last() {
+                                if let "charming_type" = segment.ident.to_string().as_str() {
+                                    match &meta_name_value.value {
+                                        syn::Expr::Lit(expr_lit) => {
+                                            if let syn::Lit::Str(lit_str) = &expr_lit.lit {
+                                                let value = lit_str.value();
+
+                                                // This sets the String to whatever value was provided in the `new` method, it is used to provide a value to type_
+                                                fields_init_values.push(
+                                                    quote! { #field_ident: #value.to_string() },
+                                                )
+                                            }
+                                        }
+                                        _ => {
+                                            panic!("charming_type needs a string literal")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if type_wrapper == "Option" && generate_setter {
+                    let field_generic_type =
+                        &type_path.path.segments.iter().next().unwrap().arguments;
+
+                    fields_init_values.push(quote! { #field_ident: None });
+
+                    // This implements a method that looks like this for a field `id: Option<String>`
+                    //```rust
+                    //pub fn id<I: Into<String>>(mut self, id: I) -> Self {
+                    //    self.id = Some(id.into());
+                    //    self
+                    //}
+                    // ```
+                    fields_setter.push(quote! {
+                        pub fn #field_ident<#field_ident_shorthand: Into #field_generic_type >(mut self, #field_ident: #field_ident_shorthand) -> Self {self.#field_ident = Some(#field_ident.into());
+                          self
+                        }
+                    });
+                } else if type_wrapper == "Vec" && generate_setter {
+                    let field_generic_type =
+                        &type_path.path.segments.iter().next().unwrap().arguments;
+
+                    fields_init_values.push(quote! { #field_ident: Vec::new() });
+
+                    // This implements a method that looks like this for a field `series: Vec<Series>`
+                    //```rust
+                    //pub fn series<S: Into<Series>>(mut self, series: S) -> Self {
+                    //    self.series.push(series.into());
+                    //    self
+                    //}
+                    // ```
+                    fields_setter.push(quote! {
+                        pub fn #field_ident<#field_ident_shorthand: Into #field_generic_type >(mut self, #field_ident: #field_ident_shorthand) -> Self {self.#field_ident.push(#field_ident.into());
+                        self}
+                    });
+                };
+            }
+            _ => todo!(),
+        }
+    }
+
+    quote! {
+        impl #struct_ident {
+            pub fn new() -> #struct_ident {
+                #struct_ident {
+                    #(#fields_init_values),*
+                }
+            }
+
+            #(#fields_setter)*
+        }
+    }
+    .into()
+}

--- a/charming_macros/src/lib.rs
+++ b/charming_macros/src/lib.rs
@@ -174,6 +174,12 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
             #(#fields_setter)*
         }
+
+        impl Default for #struct_ident {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
     }
     .into()
 }

--- a/gallery/src/line/gradient_stacked_area.rs
+++ b/gallery/src/line/gradient_stacked_area.rs
@@ -10,13 +10,7 @@ use charming::{
 
 pub fn chart() -> Chart {
     Chart::new()
-        .color(vec![
-            "#80ffa5".into(),
-            "#00ddff".into(),
-            "#37a2ff".into(),
-            "#ff0087".into(),
-            "#ffbf00".into(),
-        ])
+        .color(vec!["#80ffa5", "#00ddff", "#37a2ff", "#ff0087", "#ffbf00"])
         .title(Title::new().text("Gradient Stacked Area Chart"))
         .tooltip(
             Tooltip::new().trigger(Trigger::Axis).axis_pointer(


### PR DESCRIPTION
**Motivation**
This library is using manually implemented setter functions on almost all structs, which could be generated automatically. These manual implementation increase the effort of adding new fields to structs a lot, which is not ideal. With the implementation of the macro and the use of `serde_with` I was able to remove almost ten thousand lines of code from the repo without any changes to the end user.

**General info and implementation details**
This PR implements a derive macro to create the setter function of `components`, `elements` and  `series` automatically.

From the docs:
CharmingSetters is a derive macro for the Charming chart rendering library. It is used to remove a lot of boilerplate code in the library by implementing common methods to set the fields of structs.

Example without the macro
```rust
use serde::{Serialize, Deserialize};
use charming::component::Title;
use charming::element::{Color, Tooltip};
use charming::datatype::{DataFrame, DataPoint};

#[serde_with::apply(
  Option => #[serde(skip_serializing_if = "Option::is_none")],
  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
)]
#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
struct Component {
    title: Vec<Title>,
    tooltip: Option<Tooltip>,
    color: Vec<Color>,
    position: Option<(String, String)>,
    data: DataFrame

    // many fields cut for brevity
}
// For setting these fields with the setter pattern we would need to implement the following
// methods manually when we are not using the derive macro
impl Component {
    pub fn new() -> Self {
        Self {
            title: Vec::new(),
            tooltip: None,
            color: Vec::new(),
            position: None,
            data: DataFrame::default(),
        }
    }
    pub fn title<T: Into<Title>>(mut self, title: T) -> Self {
        self.title.push(title.into());
        self
    }
    pub fn tooltip<T: Into<Tooltip>>(mut self, tooltip: T) -> Self {
        self.tooltip = Some(tooltip.into());
        self
    }
    pub fn color<C: Into<Color>>(mut self, color: Vec<C>) -> Self {
        self.color = color.into_iter().map(|c| c.into()).collect();
        self
    }
    pub fn position<S: Into<String>>(mut self, position: (S, S)) -> Self {
        self.position = Some((position.0.into(), position.1.into()));
        self
    }
    pub fn data<D: Into<DataPoint>>(mut self, data: Vec<D>) -> Self {
        self.data = data.into_iter().map(|d| d.into()).collect();
        self
    }
    // many methods cut for brevity
}
```

Example with the macro
```rust
use serde::{Serialize, Deserialize};
use charming::component::Title;
use charming::element::{Color, Tooltip};
use charming::datatype::{DataFrame, DataPoint};
use charming_macros::CharmingSetters;

#[serde_with::apply(
  Option => #[serde(skip_serializing_if = "Option::is_none")],
  Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
)]
#[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, PartialOrd, Clone)]
struct Component {
    title: Vec<Title>,
    tooltip: Option<Tooltip>,
    #[charming_set_vec]
    color: Vec<Color>,
    #[charming_skip_setter]
    position: Option<(String, String)>,
    data: DataFrame

    // many fields cut for brevity
}

impl Component {
    pub fn position<S: Into<String>>(mut self, position: (S, S)) -> Self {
        self.position = Some((position.0.into(), position.1.into()));
        self
    }
    // All other methods from the previous example are now getting generated automatically
}
```

In the examples, you can also see that I switched to an automatic implementation using `serde_with` to add the following common attributes automatically.
```rust
#[serde(skip_serializing_if = "Option::is_none")]
#[serde(default, skip_serializing_if = "Vec::is_empty")]
```

**Breaking changes**
There are some breaking changes introduced in this PR which have nothing to do with the derive macro or the switch to `serde_with`. I introduced them with other changes here, which is not ideal, but they are very minor. The only change that will probably be noticed by current users is the first listed change.

- Breaking change with more calls of `.into()`
```rust
// As an example
pub fn color(mut self, color: Vec<Color>) -> Self {
    self.color = color;
    self
}
// Changed to 
pub fn color<C: Into<Color>>(mut self, color: Vec<C>) -> Self {
    self.color = color.into_iter().map(|c| c.into()).collect();
    self
}

// As a user of the library you might have used
Chart::new().color(vec!["#00ddff".into()]); // This will error now, you need to remove the additional `.into()` call
// Like this
Chart::new().color(vec!["00ddff"]);
```
  - If you used explicit calls of `.into()` and the compiler complains after upgrading, try to remove the `.into()` call, and it will likely fix itself
- Breaking name change in GeoMap
  - Rename `map_name` function to `name`
- Breaking type change in GraphNodeLabel
  - Changed type of `font_size` from `u64` to correct `f64`
  - This will go mostly unnoticed as we are using `Into<f64>`
- Breaking type change in several series
  - Changed type of `dataset_index` from `u64` to correct `f64`
  - This will go mostly unnoticed as we are using `Into<f64>`

**Testing**
I am pretty confident to not have introduced any breaking changes outside the ones mentioned. This is only possible due to our pretty rigorous testing, which were mostly introduced in #172 and #177.

**Current problems**
None! I think this is basically ready, I will look over it again in the coming days to make sure I haven't missed anything, but it should be good to go.