### PR TITLE
Update docs and remove dp macro

### DIFF
--- a/charming/src/datatype/dataframe.rs
+++ b/charming/src/datatype/dataframe.rs
@@ -15,7 +15,7 @@ use super::DataPoint;
 ///     [  7.2,    8.8,   18,   57]
 /// ]
 ///
-/// We can use the [`df`] macro to construct a DataFrame. For example, to
+/// We can use the [`df`](crate::df) macro to construct a DataFrame. For example, to
 /// construct the above DataFrame, you can write code like this:
 ///
 /// ```rust
@@ -35,7 +35,7 @@ use super::DataPoint;
 ///
 /// data: [1, 1, 2, 3, 5, 7, 13]
 ///
-/// We can use the second form of the [`df`] macro to construct the above
+/// We can use the second form of the [`df`](crate::df) macro to construct the above
 /// simplified DataFrame. For example, to construct the above DataFrame, you
 /// can write code like this:
 ///
@@ -48,6 +48,18 @@ use super::DataPoint;
 ///
 pub type DataFrame = Vec<DataPoint>;
 
+/// The `df` macro can construct a [DataFrame].
+/// ```rust
+/// use charming::datatype::DataFrame;
+/// use charming::df;
+///
+/// let data: DataFrame = df![
+///    [3.4, 4.5, 15, 43],
+///    [4.2, 2.3, 20, 91],
+///    [10.8, 9.5, 30, 18],
+///    [7.2, 8.8, 18, 57]
+/// ];
+/// ```
 #[macro_export]
 macro_rules! df {
     ($([$($x:expr),*]),* $(,)?) => {
@@ -70,9 +82,19 @@ macro_rules! df {
     };
 }
 
-/// Code below is modified (using df! as reference) from ChatGPT generated code.
-/// The main objective of macro dz! is to transpose mixed data type vectors,
-/// aka columns or dimensions into ECharts dataframe format.
+/// The `dz` macro can construct a [DataFrame] from mixed data types.
+/// ```rust
+/// use charming::datatype::DataFrame;
+/// use charming::dz;
+///
+/// let data: DataFrame = dz![
+///    [44056, 13334],
+///    [81.8, 76.9],
+///    [23968973, 1376048943],
+///    ["Australia", "China"],
+///    [2015, 2015]
+/// ];
+/// ```
 #[macro_export]
 macro_rules! dz {
     /*

--- a/charming/src/datatype/datapoint.rs
+++ b/charming/src/datatype/datapoint.rs
@@ -105,16 +105,6 @@ impl From<DataPointItem> for DataPoint {
     }
 }
 
-#[macro_export]
-macro_rules! dp {
-    ($v:expr) => {
-        DataPoint::new($v)
-    };
-    ($v:expr, $name:expr) => {
-        DataPoint::new($v).name($name)
-    };
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/charming/src/datatype/dimension.rs
+++ b/charming/src/datatype/dimension.rs
@@ -58,6 +58,16 @@ impl From<(&str, &str, &str)> for Dimension {
     }
 }
 
+/// The `dim` macro can construct a Vec<[Dimension]>.
+/// ```rust
+/// use charming::datatype::Dimension;
+/// use charming::dim;
+///
+/// let data: Vec<Dimension> = dim![
+///    "name1",
+///    ("name2", "number")
+/// ];
+/// ```
 #[macro_export]
 macro_rules! dim {
     ($($x:expr),*) => {

--- a/charming/src/datatype/source.rs
+++ b/charming/src/datatype/source.rs
@@ -48,6 +48,13 @@ impl From<Vec<Vec<CompositeValue>>> for DataSource {
     }
 }
 
+/// The `ds` macro can construct a [DataSource] from an array of mixed datatypes.
+/// ```rust
+/// use charming::datatype::DataSource;
+/// use charming::ds;
+///
+/// let data: DataSource = ds!([1i32, "Tuesday", 3.0f32], ["Monday", 2i32, "Wednesday"]);
+/// ```
 #[macro_export]
 macro_rules! ds {
     ($([$($x:expr),* $(,)?]),* $(,)?) => {

--- a/charming/src/datatype/value.rs
+++ b/charming/src/datatype/value.rs
@@ -88,6 +88,17 @@ where
     }
 }
 
+/// The `val` macro can construct a [CompositeValue]::Array.
+/// ```rust
+/// use charming::datatype::CompositeValue;
+/// use charming::val;
+///
+/// let data: CompositeValue = val![
+///    1,
+///    "name1",
+///    Some(1)
+/// ];
+/// ```
 #[macro_export]
 macro_rules! val {
     ($($x:expr),*) => {

--- a/charming/src/lib.rs
+++ b/charming/src/lib.rs
@@ -25,7 +25,7 @@ provides three types of renderers:
   This renderer is disabled by default, and you need to enable the `ssr`
   (Server-Side Rendering) feature to use it.
   To render raster images like PNG the `ssr-raster` feature must also be enabled.
-- **WASM renderer**: [`WasmRenderer`] renders a chart in a WebAssembly runtime.
+- **WASM renderer**: `WasmRenderer` renders a chart in a WebAssembly runtime.
   This renderer is disabled by default, and you need to enable the `wasm`
   feature to use it. Note that the `wasm` feature and `ssr` feature are
   mutually exclusive.
@@ -165,7 +165,7 @@ let chart = Chart::new()
 
 ### Legend
 
-[`Legend`] is the legend of a chart, which is used to show the meaning of the
+[`Legend`](crate::component::Legend) is the legend of a chart, which is used to show the meaning of the
 symbols and colors in the chart. A chart can have multiple legends.
 
 ```rust
@@ -204,7 +204,7 @@ let chart = Chart::new()
 
 ### Polar Coordinate
 
-[`Polar`] is the polar coordinate system. Polar coordinate can be used in
+[`PolarCoordinate`] is the polar coordinate system. Polar coordinate can be used in
 scatter and line charts. Every polar coordinate has an [`AngleAxis`] and a
 [`RadiusAxis`].
 


### PR DESCRIPTION
I fixed all broken links in the documentation and documented the macros with some examples, so users know how to use them. I also removed the `dp` macro, it never worked, so I don't count it as a breaking change.