### PR TITLE
feat: add dispose_chart method for Echarts and Leptos integration

### DIFF
--- a/charming/src/renderer/wasm_renderer.rs
+++ b/charming/src/renderer/wasm_renderer.rs
@@ -68,6 +68,46 @@ impl WasmRenderer {
         let js = serde_wasm_bindgen::to_value(&chart).unwrap();
         echarts.set_option(js);
     }
+    /// Enable disposing of chart instance
+    /// # Example
+    /// ```no_run
+    /// use charming::renderer::WasmRenderer;
+    /// use charming::Chart;
+    /// // assume `chart` is an instance of `Echarts`
+    /// # let chart = WasmRenderer::new(800,600).render("chart-id",&Chart::new()).unwrap();
+    /// WasmRenderer::dispose_chart(&chart);
+    /// ```
+    /// # Leptos Integration Example
+    ///
+    /// ```no_run
+    /// use charming::renderer::WasmRenderer;
+    /// use charming::Chart;
+    /// use leptos::prelude::*;
+    /// use std::sync::{Arc, Mutex};
+    /// #[component]
+    /// fn MyChartComponent(chart: Box<dyn Fn()-> Chart>) -> impl IntoView {
+    ///     let e_charts: Arc<Mutex<Option<Echarts>>> = Arc::new(Mutex::new(None));
+    ///     let chart_clone = e_charts.clone();
+    ///     on_cleanup(move || {
+    ///         if let Some(chart) = chart_clone.lock().unwrap().as_ref() {
+    ///             // In sometimes, you might want to dispose of the chart to free up resources,specially when the chart using custom renderItem.
+    ///            WasmRenderer::dispose_chart(chart);
+    ///         }
+    ///     });
+    ///     Effect::new(
+    ///         move |_| {
+    ///             let render = WasmRenderer::new_opt(None,None);
+    ///            *e_charts.lock().unwrap()= render.render("my-chart", &chart()).ok();
+    ///         }
+    ///     );
+    ///     view! {
+    ///         <div id="my-chart" class="w-full h-full"></div>
+    ///     }
+    /// }
+    /// ```
+    pub fn dispose_chart(echarts: &Echarts) {
+        echarts.dispose();
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Copy)]
@@ -140,4 +180,11 @@ extern "C" {
 
     #[wasm_bindgen(method, js_name = "resize")]
     pub fn resize(this: &Echarts, opts: JsValue);
+
+    #[wasm_bindgen(method, js_name = "dispose")]
+    pub fn dispose(this: &Echarts);
 }
+
+/// Enable dispose on on_cleanup function in Leptos
+unsafe impl Sync for Echarts {}
+unsafe impl Send for Echarts {}

--- a/charming/src/renderer/wasm_renderer.rs
+++ b/charming/src/renderer/wasm_renderer.rs
@@ -185,6 +185,6 @@ extern "C" {
     pub fn dispose(this: &Echarts);
 }
 
-/// Enable dispose on on_cleanup function in Leptos
+// Enable dispose on on_cleanup function in Leptos
 unsafe impl Sync for Echarts {}
 unsafe impl Send for Echarts {}


### PR DESCRIPTION
**Source of the issue**

Within the Leptos framework, encapsulating Chart-related components and using Custom::renderItem may cause the reused component to display residual custom content from the previous instance.

**Solution**

This pull request adds support for properly disposing of chart instances in the `WasmRenderer`, which is especially useful for freeing up resources in dynamic web applications, such as those built with Leptos. The main changes include introducing a `dispose_chart` method, exposing the underlying `dispose` method of the `Echarts` type to Rust, and ensuring thread safety for `Echarts` by implementing `Sync` and `Send`.

**New chart disposal support:**

* Added the `dispose_chart` method to `WasmRenderer`, allowing users to explicitly dispose of chart instances and providing detailed documentation and usage examples, including integration with Leptos's `on_cleanup` lifecycle.

**WebAssembly interop and thread safety:**

* Exposed the `dispose` method of the JavaScript `Echarts` object to Rust via `wasm_bindgen`, enabling the actual disposal logic to be called from Rust code.
* Implemented `Sync` and `Send` for the `Echarts` type, making it possible to safely share `Echarts` instances across threads, which is important for concurrent or async Rust web applications.