### PR TITLE
Fix: Support deserialising additional valid chart options 

### DIFF
--- a/charming/src/component/axis.rs
+++ b/charming/src/component/axis.rs
@@ -7,8 +7,10 @@ use crate::{
 };
 use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
+use serde_with::{DefaultOnNull, serde_as};
 
 /// Axis in cartesian coordinate.
+#[serde_as]
 #[serde_with::apply(
   Option => #[serde(skip_serializing_if = "Option::is_none")],
   Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -76,5 +78,6 @@ pub struct Axis {
     /// Settings related to split line.
     split_line: Option<SplitLine>,
     #[charming_set_vec]
+    #[serde_as(deserialize_as = "DefaultOnNull")]
     data: Vec<String>,
 }

--- a/charming/src/component/legend.rs
+++ b/charming/src/component/legend.rs
@@ -6,7 +6,8 @@ use crate::{
 };
 use charming_macros::CharmingSetters;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use serde_with::{DisplayFromStr, PickFirst, serde_as};
+use std::{collections::BTreeMap, str::FromStr};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(untagged)]
@@ -56,6 +57,17 @@ pub struct LegendItem {
     pub icon: Option<Icon>,
 }
 
+impl FromStr for LegendItem {
+    type Err = std::convert::Infallible;
+
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        Ok(Self {
+            name: name.to_string(),
+            icon: None,
+        })
+    }
+}
+
 impl From<&str> for LegendItem {
     fn from(name: &str) -> Self {
         Self {
@@ -89,6 +101,7 @@ impl From<(String, String)> for LegendItem {
     }
 }
 
+#[serde_as]
 #[serde_with::apply(
   Option => #[serde(skip_serializing_if = "Option::is_none")],
   Vec => #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -146,6 +159,7 @@ pub struct Legend {
     border_color: Option<Color>,
     inactive_color: Option<Color>,
     #[charming_set_vec]
+    #[serde_as(as = "Vec<PickFirst<(_, DisplayFromStr)>>")]
     data: Vec<LegendItem>,
     animation: Option<bool>,
     animation_duration_update: Option<AnimationTime>,

--- a/charming/src/lib.rs
+++ b/charming/src/lib.rs
@@ -91,6 +91,7 @@ pub mod renderer;
 pub mod series;
 pub mod theme;
 
+#[cfg(any(feature = "html", feature = "ssr", feature = "wasm"))]
 pub use renderer::*;
 
 use charming_macros::CharmingSetters;

--- a/charming/src/lib.rs
+++ b/charming/src/lib.rs
@@ -246,6 +246,7 @@ zoom, restore, and reset.
 #[derive(Serialize, Deserialize, CharmingSetters, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Chart {
+    #[serde_as(as = "OneOrMany<_, PreferOne>")]
     title: Vec<Title>,
     animation: Option<bool>,
     animation_duration: Option<AnimationTime>,
@@ -258,6 +259,7 @@ pub struct Chart {
     tooltip: Option<Tooltip>,
     legend: Option<LegendConfig>,
     toolbox: Option<Toolbox>,
+    #[serde_as(as = "OneOrMany<_, PreferOne>")]
     grid: Vec<Grid>,
     #[serde(rename = "grid3D")]
     grid3d: Vec<Grid3D>,

--- a/charming/src/theme/mod.rs
+++ b/charming/src/theme/mod.rs
@@ -19,6 +19,7 @@ pub enum Theme {
 }
 
 impl Theme {
+    #[cfg(any(feature = "html", feature = "ssr"))]
     pub(crate) fn to_str(&self) -> (&'static str, &'static str) {
         match self {
             Theme::Default => ("", ""),

--- a/charming/tests/deserialize.rs
+++ b/charming/tests/deserialize.rs
@@ -92,4 +92,128 @@ mod tests {
             "Expected an error for incomplete data, but deserialization succeeded"
         );
     }
+
+    #[test]
+    fn test_deserialize_chart_more_flexibility() {
+        let chart_str = r##"{
+          "animationDurationUpdate": 800,
+          "animationEasingUpdate": "quinticInOut",
+          "grid": {
+            "bottom": "50",
+            "containsLabel": true,
+            "left": "70",
+            "right": "30",
+            "show": false,
+            "top": "40"
+          },
+          "legend": {
+            "bottom": 10,
+            "data": [
+              "Type1",
+              "Type2",
+              "Type3",
+              "Type4",
+              "Type5",
+              "Type6"
+            ],
+            "itemGap": 15,
+            "itemHeight": 14,
+            "itemWidth": 14,
+            "orient": "horizontal",
+            "show": true,
+            "textStyle": {
+              "fontSize": 12
+            }
+          },
+          "series": [
+            {
+              "animation": true,
+              "animationDuration": 1000,
+              "animationEasing": "bounceOut",
+              "data": [
+                {
+                  "name": "Type1",
+                  "value": 3750
+                },
+                {
+                  "name": "Type2",
+                  "value": 1100
+                },
+                {
+                  "name": "Type3",
+                  "value": 3000
+                },
+                {
+                  "name": "Type4",
+                  "value": 500
+                },
+                {
+                  "name": "Type5",
+                  "value": 12000
+                },
+                {
+                  "name": "Type6",
+                  "value": 12000
+                }
+              ],
+              "emphasis": {
+                "itemStyle": {
+                  "shadowBlur": 10,
+                  "shadowColor": "rgba(0, 0, 0, 0.5)",
+                  "shadowOffsetX": 0
+                }
+              },
+              "name": "",
+              "radius": "50%",
+              "type": "pie"
+            }
+          ],
+          "textStyle": {
+            "color": "#000A26",
+            "fontFamily": "Inter",
+            "fontSize": 12
+          },
+          "title": {
+            "left": 5,
+            "show": false,
+            "text": "Demo pie chart",
+            "textStyle": {
+              "color": "#000A26",
+              "fontSize": 18,
+              "fontWeight": 600
+            }
+          },
+          "tooltip": {
+            "axisPointer": {
+              "type": "shadow"
+            },
+            "show": true,
+            "trigger": "item"
+          },
+          "xAxis": {
+            "axisPointer": {
+              "show": false
+            },
+            "data": [],
+            "name": "",
+            "nameGap": 30,
+            "nameLocation": "middle",
+            "show": false,
+            "type": "category"
+          },
+          "yAxis": {
+            "axisPointer": {
+              "show": false
+            },
+            "data": null,
+            "name": "",
+            "nameGap": 70,
+            "nameLocation": "middle",
+            "show": false,
+            "type": "value"
+          }
+        }"##;
+
+        serde_json::from_str::<Chart>(chart_str).expect("Should be able to deserialize chart");
+    }
 }

--- a/charming/tests/deserialize.rs
+++ b/charming/tests/deserialize.rs
@@ -14,13 +14,13 @@ mod tests {
                 let chart = chart_builder();
                 let json_string = serde_json::to_string(&chart).unwrap_or_else(|e| {
                     panic!(
-                        "Shold be able to serialize sub chart: {sub_key} in {key} charts category, error message: {e}"
+                        "Should be able to serialize sub chart: {sub_key} in {key} charts category, error message: {e}"
                     )
                 });
 
                 let deserialized_chart:Chart = serde_json::from_str(&json_string).unwrap_or_else(|e| {
                     panic!(
-                        "Shold be able to deserialize sub chart: {sub_key} in {key} charts category, error message: {e}"
+                        "Should be able to deserialize sub chart: {sub_key} in {key} charts category, error message: {e}"
                     )
                 });
 


### PR DESCRIPTION
I was tying to use charming for the type definitions but discovered that it was unable to deserialise some valid chart options.

I have therefore updated the deserialisation to support this. There is an additional test with a valid chart options json that used to fail to decode.

I also fixed a couple of warnings I saw when using `--no-default-features` and a couple of typos.